### PR TITLE
Option to add APIC nested domain fields from user

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -64,6 +64,7 @@ module "topology" {
   cluster_id          = var.cluster_id
   cluster_domain      = var.cluster_domain
   external_network    = var.openstack_external_network
+  aci_net_ext         = var.openstack_aci_net_ext
   external_network_id = var.openstack_external_network_id
   masters_count       = var.master_count
   lb_floating_ip      = var.openstack_lb_floating_ip

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -2,14 +2,6 @@ locals {
   nodes_cidr_block = "192.168.0.0/16"
 }
 
-variable "aci-net-ext" {
- type = "map"
- default = {"apic:nested_domain_infra_vlan"="4093"
-            "apic:nested_domain_node_network_vlan"="1021"
-            "apic:nested_domain_service_vlan"="1022"
-           }
-}
-
 data "openstack_networking_network_v2" "external_network" {
   name       = var.external_network
   network_id = var.external_network_id
@@ -20,7 +12,11 @@ resource "openstack_networking_network_v2" "openshift-private" {
   name           = "${var.cluster_id}-openshift"
   admin_state_up = "true"
   tags           = ["openshiftClusterID=${var.cluster_id}"]
-  value_specs    = var.aci-net-ext
+  value_specs    = {
+    "apic:nested_domain_infra_vlan"        : var.aci_net_ext["infra_vlan"],
+    "apic:nested_domain_node_network_vlan" : var.aci_net_ext["kube_api_vlan"],
+    "apic:nested_domain_service_vlan"      : var.aci_net_ext["service_vlan"],
+  }
 }
 
 resource "openstack_networking_subnet_v2" "nodes" {

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -17,6 +17,12 @@ variable "external_network" {
   default     = ""
 }
 
+variable "aci_net_ext" {
+ description = "Network extensions fields for APIC"
+ type = "map"
+ default = {}
+}
+
 variable "external_network_id" {
   description = "UUID of the external network providing Floating IP addresses."
   type        = string

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -246,6 +246,17 @@ EOF
 
 }
 
+variable "openstack_aci_net_ext" {
+  type = "map"
+  default = {}
+
+  description = <<EOF
+(optional) Network extension fields required by APIC. Please provide
+map with keys "infra_vlan", "kube_api_vlan" and "service_vlan"
+EOF
+
+}
+
 variable "openstack_external_network_id" {
   type    = string
   default = ""

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -324,13 +324,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
                          
                 logrus.Infof("Editing Bootstrap ign here...")
                 bootstrapIgn = strings.Replace(bootstrapIgn, `--container-runtime=remote`,`--container-runtime=remote \\\n   --address=10.11.0.11`, -1)
-                logrus.Infof("After Editing",bootstrapIgn)
+                logrus.Debug("After Editing",bootstrapIgn)
 
 
 		data, err = openstacktfvars.TFVars(
 			masters[0].Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec),
 			installConfig.Config.Platform.OpenStack.Cloud,
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
+                        installConfig.Config.Platform.OpenStack.AciNetExt,
 			installConfig.Config.Platform.OpenStack.ExternalDNS,
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,
 			apiVIP.String(),

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -15,29 +15,37 @@ import (
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 )
 
+type AciNetExtStruct struct {
+        InfraVLAN              string   `json:"infra_vlan,omitempty"`
+        KubeApiVLAN            string   `json:"kube_api_vlan,omitempty"`
+        ServiceVLAN            string   `json:"service_vlan,omitempty"`
+}
+
 type config struct {
-	BaseImageName          string   `json:"openstack_base_image_name,omitempty"`
-	BaseImageLocalFilePath string   `json:"openstack_base_image_local_file_path,omitempty"`
-	ExternalNetwork        string   `json:"openstack_external_network,omitempty"`
-	Cloud                  string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName             string   `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP           string   `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP                 string   `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP                 string   `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP             string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport           string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport         string   `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize         int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType         string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim          string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS            []string `json:"openstack_external_dns,omitempty"`
+	BaseImageName          string            `json:"openstack_base_image_name,omitempty"`
+	BaseImageLocalFilePath string            `json:"openstack_base_image_local_file_path,omitempty"`
+	ExternalNetwork        string            `json:"openstack_external_network,omitempty"`
+        AciNetExt              AciNetExtStruct   `json:"openstack_aci_net_ext",omitempty`
+	Cloud                  string            `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName             string            `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP           string            `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP                 string            `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP                 string            `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP             string            `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport           string            `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport         string            `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize         int               `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType         string            `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim          string            `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS            []string          `json:"openstack_external_dns,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, aciNetExtInput AciNetExtStruct, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string) ([]byte, error) {
 
 	cfg := &config{
 		ExternalNetwork: externalNetwork,
+                AciNetExt:       aciNetExtInput,
 		Cloud:           cloud,
 		FlavorName:      masterConfig.Flavor,
 		LbFloatingIP:    lbFloatingIP,

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -1,5 +1,7 @@
 package openstack
 
+import "github.com/openshift/installer/pkg/tfvars/openstack"
+
 // Platform stores all the global configuration that all
 // machinesets use.
 type Platform struct {
@@ -18,6 +20,9 @@ type Platform struct {
 
 	// ExternalNetwork is name of the external network in your OpenStack cluster.
 	ExternalNetwork string `json:"externalNetwork"`
+
+        // AciNetExt is the name of the map for APIC nested domain fields
+        AciNetExt openstack.AciNetExtStruct `json:"aciNetExt"`
 
 	// FlavorName is the name of the compute flavor to use for instances in this cluster.
 	FlavorName string `json:"computeFlavor"`


### PR DESCRIPTION
Add this map to the install config
platform:
  openstack:
    aciNetExt:
      "infra_vlan": 4093
      "kube_api_vlan": 1021
      "service_vlan": 1022

 Author:    Apoorva <apoorva.mittal2@gmail.com>

Conflicts:
	data/data/openstack/topology/private-network.tf