### PR TITLE
Add iptable rule for igmp and modify input field names

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -9,9 +9,9 @@ resource "openstack_networking_network_v2" "openshift-private" {
   admin_state_up = "true"
   tags           = ["openshiftClusterID=${var.cluster_id}"]
   value_specs    = {
-    "apic:nested_domain_infra_vlan"        : var.aci_net_ext["infra_vlan"],
-    "apic:nested_domain_node_network_vlan" : var.aci_net_ext["kube_api_vlan"],
-    "apic:nested_domain_service_vlan"      : var.aci_net_ext["service_vlan"],
+    "apic:nested_domain_infra_vlan"        : var.aci_net_ext["infraVlan"],
+    "apic:nested_domain_node_network_vlan" : var.aci_net_ext["kubeApiVlan"],
+    "apic:nested_domain_service_vlan"      : var.aci_net_ext["serviceVlan"],
   }
 }
 

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -252,7 +252,7 @@ variable "openstack_aci_net_ext" {
 
   description = <<EOF
 (optional) Network extension fields required by APIC. Please provide
-map with keys "infra_vlan", "kube_api_vlan" and "service_vlan"
+map with keys "infraVlan", "kubeApiVlan" and "serviceVlan"
 EOF
 
 }

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -150,7 +150,6 @@ func (a *Bootstrap) Generate(dependencies asset.Parents) error {
         kube_api_vlan := installConfig.Config.Platform.OpenStack.AciNetExt.KubeApiVLAN
         mtu_value := installConfig.Config.Platform.OpenStack.AciNetExt.Mtu
         networkScriptString, _ := ign.NetworkScript(kube_api_vlan, defaultGateway.String(), mtu_value)
-        logrus.Debug(string(networkScriptString))
 
         neutronCIDR := &installConfig.Config.Platform.OpenStack.NeutronCIDR.IPNet
         defaultNeutronGateway, _ := cidr.Host(neutronCIDR, 1)

--- a/pkg/asset/ignition/device.go
+++ b/pkg/asset/ignition/device.go
@@ -103,6 +103,9 @@ chmod 420 $FILE_PATH
 # Restarting Network Manager
 systemctl restart NetworkManager
 
+# Add iptable rule to accept igmp
+iptables -I INPUT 1 -j ACCEPT -p igmp
+
 `))
 
 func NetworkScript(vlan string, defGateway string, mtu string) ([]byte, error) {

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -19,9 +19,9 @@ import (
 )
 
 type AciNetExtStruct struct {
-        InfraVLAN              string   `json:"infra_vlan,omitempty"`
-        KubeApiVLAN            string   `json:"kube_api_vlan,omitempty"`
-        ServiceVLAN            string   `json:"service_vlan,omitempty"`
+        InfraVLAN              string   `json:"infraVlan,omitempty"`
+        KubeApiVLAN            string   `json:"kubeApiVlan,omitempty"`
+        ServiceVLAN            string   `json:"serviceVlan,omitempty"`
         Mtu                    string   `json:"mtu,omitempty"`
 }
 

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -28,21 +28,20 @@ func SetPlatformDefaults(p *openstack.Platform, installConfig *types.InstallConf
         }
         // Panic if input neutron CIDR and machine CIDR don't have equal masks.
         // If no neutron CIDR provided, set it to 192.168.0.0 with the machine CIDR mask
-        machineMask := installConfig.Networking.MachineCIDR.Mask
+        machineNet :=  &installConfig.Networking.MachineCIDR.IPNet
+        machineMask := machineNet.Mask
         if p.NeutronCIDR.String() != "" {
-                neutronMask := p.NeutronCIDR.Mask
+                neutronNet := &p.NeutronCIDR.IPNet
+                neutronMask := neutronNet.Mask
                 if machineMask.String() != neutronMask.String() {
                         panic("Machine CIDR and Neutron CIDR have different subnet masks")
-                        
+ 
                 }
         } else {
-                neutronIP := net.ParseIP("192.168.0.0")
-                p.NeutronCIDR = &ipnet.IPNet{
-                                        IPNet: net.IPNet{
-                                                IP:   neutronIP,
-                                                Mask: machineMask,
-                                        },
-                                }
+                machineNetString := machineNet.String()
+                machineMaskString := strings.Split(machineNetString, "/")[1]
+                neutronCIDRString := "192.168.0.0/" + machineMaskString
+                p.NeutronCIDR = ipnet.MustParseCIDR(neutronCIDRString)
         }
         installConfig.Networking.NeutronCIDR = p.NeutronCIDR
 

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -31,7 +31,7 @@ type Platform struct {
         NeutronCIDR *ipnet.IPNet `json:"neutronCIDR,omitempty"`
 
         // Installer host subnet
-        InstallerHostSubnet string `json:"installer_host_subnet",omitempty`
+        InstallerHostSubnet string `json:"installerHostSubnet",omitempty`
 
 	// FlavorName is the name of the compute flavor to use for instances in this cluster.
 	FlavorName string `json:"computeFlavor"`


### PR DESCRIPTION
Add this map to the install config for apic nested domain fields
platform:
  openstack:
    aciNetExt:
      "infraVlan": 4093
      "kubeApiVlan": 1021
      "serviceVlan": 1022

installer_host_subnet field is now installerHostSubnet
platform:
  openstack:
    installerHostSubnet: 1.103.2.0/24  # mandatory field