### PR TITLE
Validate acc-provision and edit cluster-network files

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+        "gopkg.in/yaml.v2"
 	"io/ioutil"
+        "log"
+        "os"
+        "os/exec"
 	"path/filepath"
+        "strconv"
 	"strings"
 	"time"
 
@@ -31,6 +36,7 @@ import (
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	targetassets "github.com/openshift/installer/pkg/asset/targets"
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
+        types "github.com/openshift/installer/pkg/types/validation"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 )
 
@@ -145,6 +151,7 @@ func newCreateCmd() *cobra.Command {
 }
 
 func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
+
 	runner := func(directory string) error {
 		assetStore, err := assetstore.NewStore(directory)
 		if err != nil {
@@ -168,6 +175,53 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 
 			if err != nil {
 				return err
+			}
+                        if a.Name() == "Openshift Manifests" {
+
+				// Append to cluster-network-02 files with status field
+				manifestsDir := "manifests/"
+                                files, err := ioutil.ReadDir(manifestsDir)
+    				if err != nil {
+        				log.Fatal(err)
+   	 			}
+				var cluster02file string
+
+				t := types.ClusterConfig03{}
+    				for _, f := range files {
+					if strings.Contains(f.Name(), "cluster-network-02") {
+						cluster02file = f.Name()
+					}
+    				}
+				cluster02file = manifestsDir + cluster02file
+
+				// Read the cluster-network-02 to get values:
+				yamlFile, err := ioutil.ReadFile(cluster02file)
+    				if err != nil {
+        				log.Printf("yamlFile.Get err   #%v ", err)
+    				}
+   				err = yaml.Unmarshal(yamlFile, &t)
+    				if err != nil {
+        				log.Fatalf("Unmarshal: %v", err)
+    				}
+
+				appendString := "status:\n  clusterNetwork:\n  - cidr: " + t.Spec.ClusterNetwork[0].CIDR +"\n    hostPrefix: " + strconv.Itoa(int(t.Spec.ClusterNetwork[0].HostPrefix)) + "\n  networkType: " + t.Spec.NetworkType + "\n  serviceNetwork:\n  - " + t.Spec.ServiceNetwork[0] + "\n"
+
+				// Delete the last line of 02 file, to delete the empty status
+				cmdOutput, _ := exec.Command("sed", "$d", cluster02file).Output()
+				err = ioutil.WriteFile(cluster02file, cmdOutput, 0644)
+				if err != nil {
+                                        log.Fatalf("failed writing file: %s", err)
+                                }
+
+                                file, err := os.OpenFile(cluster02file, os.O_WRONLY|os.O_APPEND, 0644)
+                                if err != nil {
+                                	log.Fatalf("failed opening file: %s", err)
+                                }
+                                _, err = file.WriteString(appendString)
+                                if err != nil {
+                                        log.Fatalf("failed writing to file: %s", err)
+                                }
+                                file.Close()
 			}
 		}
 		return nil

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -321,7 +321,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return err
 		}
                          
-                neutronCIDR := &installConfig.Config.Platform.OpenStack.NeutronCIDR.IPNet
+                neutronCIDR := &installConfig.Config.Platform.OpenStack.AciNetExt.NeutronCIDR.IPNet
                 neutronCIDRString := neutronCIDR.String()
 
 		data, err = openstacktfvars.TFVars(

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -152,11 +152,11 @@ func (a *Bootstrap) Generate(dependencies asset.Parents) error {
         mtu_value := installConfig.Config.Platform.OpenStack.AciNetExt.Mtu
         networkScriptString, _ := ign.NetworkScript(kube_api_vlan, defaultGateway.String(), mtu_value)
 
-        neutronCIDR := &installConfig.Config.Platform.OpenStack.NeutronCIDR.IPNet
+        neutronCIDR := &installConfig.Config.Platform.OpenStack.AciNetExt.NeutronCIDR.IPNet
         defaultNeutronGateway, _ := cidr.Host(neutronCIDR, 1)
         defaultNeutronGatewayStr := defaultNeutronGateway.String()
 
-        installerHostSubnet := installConfig.Config.Platform.OpenStack.InstallerHostSubnet
+        installerHostSubnet := installConfig.Config.Platform.OpenStack.AciNetExt.InstallerHostSubnet
         installerHostIP, installerHostNet, _ := net.ParseCIDR(installerHostSubnet)
         installerNetmask := net.IP(installerHostNet.Mask)
 

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -55,11 +55,11 @@ func (a *Master) Generate(dependencies asset.Parents) error {
         networkScriptString, _ := ign.NetworkScript(kube_api_vlan, defaultGateway.String(), mtu_value)
         logrus.Debug(string(networkScriptString))
 
-        neutronCIDR := &installConfig.Config.Platform.OpenStack.NeutronCIDR.IPNet
+        neutronCIDR := &installConfig.Config.Platform.OpenStack.AciNetExt.NeutronCIDR.IPNet
         defaultNeutronGateway, _ := cidr.Host(neutronCIDR, 1)
         defaultNeutronGatewayStr := defaultNeutronGateway.String()
 
-        installerHostSubnet := installConfig.Config.Platform.OpenStack.InstallerHostSubnet
+        installerHostSubnet := installConfig.Config.Platform.OpenStack.AciNetExt.InstallerHostSubnet
         installerHostIP, installerHostNet, _ := net.ParseCIDR(installerHostSubnet)
         installerNetmask := net.IP(installerHostNet.Mask)
 

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -55,11 +55,11 @@ func (a *Worker) Generate(dependencies asset.Parents) error {
         networkScriptString, _ := ign.NetworkScript(kube_api_vlan, defaultGateway.String(), mtu_value)
         logrus.Debug(string(networkScriptString))
 
-        neutronCIDR := &installConfig.Config.Platform.OpenStack.NeutronCIDR.IPNet
+        neutronCIDR := &installConfig.Config.Platform.OpenStack.AciNetExt.NeutronCIDR.IPNet
         defaultNeutronGateway, _ := cidr.Host(neutronCIDR, 1)
         defaultNeutronGatewayStr := defaultNeutronGateway.String()
 
-        installerHostSubnet := installConfig.Config.Platform.OpenStack.InstallerHostSubnet
+        installerHostSubnet := installConfig.Config.Platform.OpenStack.AciNetExt.InstallerHostSubnet
         installerHostIP, installerHostNet, _ := net.ParseCIDR(installerHostSubnet)
         installerNetmask := net.IP(installerHostNet.Mask)
 

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -13,41 +13,35 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+        "github.com/openshift/installer/pkg/types/openstack"
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 )
 
-type AciNetExtStruct struct {
-        InfraVLAN              string   `json:"infraVlan,omitempty"`
-        KubeApiVLAN            string   `json:"kubeApiVlan,omitempty"`
-        ServiceVLAN            string   `json:"serviceVlan,omitempty"`
-        Mtu                    string   `json:"mtu,omitempty"`
-}
-
 type config struct {
-	BaseImageName          string            `json:"openstack_base_image_name,omitempty"`
-	BaseImageLocalFilePath string            `json:"openstack_base_image_local_file_path,omitempty"`
-	ExternalNetwork        string            `json:"openstack_external_network,omitempty"`
-        AciNetExt              AciNetExtStruct   `json:"openstack_aci_net_ext",omitempty`
-        NeutronCIDR            string            `json:"openstack_neutron_cidr",omitempty`
-        NeutronCIDREnd         int               `json:"openstack_neutron_cidr_end",omitempty`
-	Cloud                  string            `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName             string            `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP           string            `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP                 string            `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP                 string            `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP             string            `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport           string            `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport         string            `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize         int               `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType         string            `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim          string            `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS            []string          `json:"openstack_external_dns,omitempty"`
+	BaseImageName          string                      `json:"openstack_base_image_name,omitempty"`
+	BaseImageLocalFilePath string                      `json:"openstack_base_image_local_file_path,omitempty"`
+	ExternalNetwork        string                      `json:"openstack_external_network,omitempty"`
+        AciNetExt              openstack.AciNetExtStruct   `json:"openstack_aci_net_ext",omitempty`
+        NeutronCIDR            string                      `json:"openstack_neutron_cidr",omitempty`
+        NeutronCIDREnd         int                         `json:"openstack_neutron_cidr_end",omitempty`
+	Cloud                  string                      `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName             string                      `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP           string                      `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP                 string                      `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP                 string                      `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP             string                      `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport           string                      `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport         string                      `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize         int                         `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType         string                      `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim          string                      `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS            []string                    `json:"openstack_external_dns,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, aciNetExtInput AciNetExtStruct, neutronCIDR string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, aciNetExtInput openstack.AciNetExtStruct, neutronCIDR string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string) ([]byte, error) {
 
         neutron_mask, _ := strconv.Atoi(strings.Split(neutronCIDR, "/")[1])
         neutron_end := int(math.Pow(2, float64(32 - neutron_mask)) - 2)

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -30,8 +30,8 @@ func SetPlatformDefaults(p *openstack.Platform, installConfig *types.InstallConf
         // If no neutron CIDR provided, set it to 192.168.0.0 with the machine CIDR mask
         machineNet :=  &installConfig.Networking.MachineCIDR.IPNet
         machineMask := machineNet.Mask
-        if p.NeutronCIDR.String() != "" {
-                neutronNet := &p.NeutronCIDR.IPNet
+        if p.AciNetExt.NeutronCIDR.String() != "" {
+                neutronNet := &p.AciNetExt.NeutronCIDR.IPNet
                 neutronMask := neutronNet.Mask
                 if machineMask.String() != neutronMask.String() {
                         panic("Machine CIDR and Neutron CIDR have different subnet masks")
@@ -41,11 +41,11 @@ func SetPlatformDefaults(p *openstack.Platform, installConfig *types.InstallConf
                 machineNetString := machineNet.String()
                 machineMaskString := strings.Split(machineNetString, "/")[1]
                 neutronCIDRString := "192.168.0.0/" + machineMaskString
-                p.NeutronCIDR = ipnet.MustParseCIDR(neutronCIDRString)
+                p.AciNetExt.NeutronCIDR = ipnet.MustParseCIDR(neutronCIDRString)
         }
-        installConfig.Networking.NeutronCIDR = p.NeutronCIDR
+        installConfig.Networking.NeutronCIDR = p.AciNetExt.NeutronCIDR
 
-        ipnet.MustParseCIDR(p.InstallerHostSubnet)
+        ipnet.MustParseCIDR(p.AciNetExt.InstallerHostSubnet)
 }
 
 // APIVIP returns the internal virtual IP address (VIP) put in front

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -2,8 +2,17 @@ package openstack
 
 import (
         "github.com/openshift/installer/pkg/ipnet"
-        "github.com/openshift/installer/pkg/tfvars/openstack"
 )
+
+type AciNetExtStruct struct {
+        InfraVLAN               string          `json:"infraVlan,omitempty"`
+        KubeApiVLAN             string          `json:"kubeApiVlan,omitempty"`
+        ServiceVLAN             string          `json:"serviceVlan,omitempty"`
+        Mtu                     string          `json:"mtu,omitempty"`
+        ProvisionTar            string		`json:"provisionTar,omitempty"`
+        NeutronCIDR             *ipnet.IPNet    `json:"neutronCIDR,omitempty"`
+        InstallerHostSubnet	string          `json:"installerHostSubnet"`
+}
 
 // Platform stores all the global configuration that all
 // machinesets use.
@@ -25,13 +34,7 @@ type Platform struct {
 	ExternalNetwork string `json:"externalNetwork"`
 
         // AciNetExt is the name of the map for APIC nested domain fields
-        AciNetExt openstack.AciNetExtStruct `json:"aciNetExt"`
-
-        // Neutron CIDR 
-        NeutronCIDR *ipnet.IPNet `json:"neutronCIDR,omitempty"`
-
-        // Installer host subnet
-        InstallerHostSubnet string `json:"installerHostSubnet"`
+        AciNetExt AciNetExtStruct `json:"aciNetExt"`
 
 	// FlavorName is the name of the compute flavor to use for instances in this cluster.
 	FlavorName string `json:"computeFlavor"`

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1,15 +1,25 @@
 package validation
 
 import (
+        "archive/tar"
+        "bytes"
+	"compress/gzip"
 	"fmt"
+        "gopkg.in/yaml.v2"
+        "io"
+        "io/ioutil"
+        "log"
 	"net"
+        "os"
 	"sort"
+        "strconv"
 	"strings"
 
 	dockerref "github.com/containers/image/docker/reference"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+        "github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	awsvalidation "github.com/openshift/installer/pkg/types/aws/validation"
@@ -31,6 +41,51 @@ import (
 const (
 	masterPoolName = "master"
 )
+
+type AciContainersConfig struct {
+        Data ConfigData `yaml:data,omitempty`
+}
+
+type ConfigData struct {
+        HostConfig string `yaml:"host-agent-config"`
+}
+
+type HostConfigMap struct {
+        ServiceVLAN int    `yaml:"service-vlan"`
+        InfraVLAN   int    `yaml:"aci-infra-vlan"`
+        KubeApiVLAN int    `yaml:"kubeapi-vlan"`
+        PodSubnet   string `yaml:"pod-subnet"`
+        NodeSubnet  string `yaml:"node-subnet"`
+}
+
+type ClusterConfig03 struct {
+	ApiVersion string     `yaml:"apiVersion"`
+        Kind       string     `yaml:"kind"`
+        Metadata   MetaEntry  `yaml:"metadata,omitempty"`
+	Spec       SpecEntry  `yaml:"spec,omitempty"`
+}
+
+type MetaEntry struct {
+	Name	string `yaml:"name"`
+}
+
+type SpecEntry struct {
+	Multus		string				`yaml:"disableMultiNetwork"`
+        ClusterNetwork	[]ClusterEntry 			`yaml:"clusterNetwork,omitempty"`  
+        DefaultNetwork  DefaultNetEntry			`yaml:"defaultNetwork,omitempty"`
+        NetworkType	string				`yaml:"networkType,omitempty"`
+        ServiceNetwork	[]string			`yaml:"serviceNetwork,omitempty"`
+}
+
+type ClusterEntry struct {
+        CIDR		string	`yaml:"cidr"`
+	HostPrefix	int32	`yaml:"hostPrefix"`
+}
+
+type DefaultNetEntry struct {
+	Type	string	`yaml:"type"`
+}
+
 
 // ClusterDomain returns the cluster domain for a cluster with the specified
 // base domain and cluster name.
@@ -99,7 +154,120 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	if _, ok := validPublishingStrategies[c.Publish]; !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("publish"), c.Publish, validPublishingStrategyValues))
 	}
+        r, err := os.Open(c.Platform.OpenStack.AciNetExt.ProvisionTar)
+        if err != nil {
+        	fmt.Println("error")
+    	}
+        serviceNetwork := c.Networking.ServiceNetwork[0].String()
+        hostPrefix := c.Networking.ClusterNetwork[0].HostPrefix
+        networkType := c.Networking.NetworkType
+	clusterNetworkCIDR := &c.Networking.ClusterNetwork[0].CIDR
+        config := ExtractTarGz(r, serviceNetwork, clusterNetworkCIDR.String(), hostPrefix, networkType)
+        machineCIDR := c.Networking.MachineCIDR
+        // Validate against values from install config
+        if (strconv.Itoa(config.InfraVLAN) != c.Platform.OpenStack.AciNetExt.InfraVLAN) ||
+               (strconv.Itoa(config.ServiceVLAN) != c.Platform.OpenStack.AciNetExt.ServiceVLAN) ||
+                       (strconv.Itoa(config.KubeApiVLAN) != c.Platform.OpenStack.AciNetExt.KubeApiVLAN) ||
+                           DiffSubnets(config.NodeSubnet, machineCIDR) ||
+                               DiffSubnets(config.PodSubnet, clusterNetworkCIDR) {
+                                       panic("Install config and acc-provision not in sync")
+        }
 	return allErrs
+}
+
+func DiffSubnets(sub1 string, sub2 *ipnet.IPNet) bool {
+        // Returns True if the subnets are different
+        _, net1, _ := net.ParseCIDR(sub1)
+        if net1.String() != sub2.String() {
+                return true
+	}
+        return false
+}
+
+func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, hostPrefix int32, netType string) HostConfigMap {
+        uncompressedStream, err := gzip.NewReader(gzipStream)
+        if err != nil {
+                panic("ExtractTarGz: NewReader failed")
+        }
+
+        tarReader := tar.NewReader(uncompressedStream)
+
+        manifests_dir := "manifests"
+        os.Mkdir(manifests_dir, 0777)
+        config := HostConfigMap{}
+
+        for true {
+                header, err := tarReader.Next()
+
+                if err == io.EOF {
+                        break
+                }
+
+                if err != nil {
+                        log.Fatalf("ExtractTarGz: Next() failed: %s", err.Error())
+                }
+
+                switch header.Typeflag {
+                case tar.TypeReg:
+
+                        fileName := manifests_dir + "/" + header.Name
+                        outFile, err := os.Create(fileName)
+                        if err != nil {
+                                log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
+                        }
+
+                        var buf bytes.Buffer
+                        teeReader := io.TeeReader(tarReader, &buf)
+                        temp, _ := ioutil.ReadAll(teeReader)
+
+			// Unmarshal acc configmap to get acc-provision values
+                        if strings.Contains(header.Name, "aci-containers-config") {
+                                t := AciContainersConfig{}
+                                err1 := yaml.Unmarshal(temp, &t)
+                                if err1 != nil {
+                                        log.Fatalf("error: %v", err1)
+                                }
+                                err2 := yaml.Unmarshal([]byte(t.Data.HostConfig), &config)
+                                if err2 != nil {
+                                        log.Fatalf("error: %v", err2)
+                                }
+                        }
+
+			// Set cluster-network-03 fields as provided in install-config.yaml
+                        if strings.Contains(header.Name, "cluster-network-03") {
+                                t := ClusterConfig03{}
+                                err1 := yaml.Unmarshal(temp, &t)
+                                if err1 != nil {
+                                        log.Fatalf("error: %v", err1)
+                                }
+				t.Spec.ClusterNetwork[0].CIDR = clusterCIDR
+                                t.Spec.ClusterNetwork[0].HostPrefix = hostPrefix
+                                t.Spec.ServiceNetwork[0] = serviceNet
+                                t.Spec.DefaultNetwork.Type = netType
+                                d, err := yaml.Marshal(&t)
+				if err != nil {
+					log.Fatalf("error: %v", err)
+				}
+                                
+				err = ioutil.WriteFile(fileName, d, 0640)
+                                if err != nil {
+					log.Fatal(err)
+				}
+                        } else {
+                        	if _, err := io.Copy(outFile, &buf); err != nil {
+                                	log.Fatalf("ExtractTarGz: Copy() failed: %s", err.Error())
+                        	}
+                        	outFile.Close()
+			}
+                default:
+                        log.Fatalf(
+                                "ExtractTarGz: unknown type: %s in %s",
+                                header.Typeflag,
+                                header.Name)
+                }
+
+        }
+        return config
 }
 
 func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorList {


### PR DESCRIPTION
- MachineCIDR and node-subnet should match
- ClusterNetwork CIDR and pod-subnet should match
- KubeApiVlan, serviceVlan and infraVlan should match

- neutronCIDR and installerHostSubnet fields go under aciNetExt in install-config.yaml
- Add full filepath for acc-provision tar in aciNetExt, like:
  openstack:
    aciNetExt:
      "infraVlan": 4093
      "kubeApiVlan": 1026
      "serviceVlan": 1027
      "provisionTar": /home/noiro/apoorva/aci_deployment.yaml.tar.gz
      neutronCIDR: 192.168.0.0/27
      installerHostSubnet: 1.109.2.0/24

- acc-provision manifest files from the tar are now automatically saved into the "manifests" dir along with the other installer files
- Set serviceNetwork, defaultNetwork and clusterNetwork fields in cluster-network-03-config.yaml using values provided in install-config