### PR TITLE
Option to set subnet and create Cluster SNAT

### DIFF
--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -12,6 +12,7 @@ type AciNetExtStruct struct {
         ProvisionTar            string		`json:"provisionTar,omitempty"`
         NeutronCIDR             *ipnet.IPNet    `json:"neutronCIDR,omitempty"`
         InstallerHostSubnet	string          `json:"installerHostSubnet"`
+	ClusterSNATSubnet       string          `json:"clusterSNATSubnet"`
 }
 
 // Platform stores all the global configuration that all

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"errors"
+        "net"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -66,6 +67,17 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 		}
 	}
 
+	// Check if snatCRSubnet is a valid subnet or IP
+	if p.AciNetExt.ClusterSNATSubnet != "" {
+		_, _, err := net.ParseCIDR(p.AciNetExt.ClusterSNATSubnet)
+		if err != nil {
+			ip := net.ParseIP(p.AciNetExt.ClusterSNATSubnet)
+			if ip == nil {
+				// error
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("ClusterSNATSubnet"), p.AciNetExt.ClusterSNATSubnet, err.Error()))
+			}	
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -8,7 +8,6 @@ import (
         "gopkg.in/yaml.v2"
         "io"
         "io/ioutil"
-        "log"
 	"net"
         "os"
 	"sort"
@@ -154,24 +153,47 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	if _, ok := validPublishingStrategies[c.Publish]; !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("publish"), c.Publish, validPublishingStrategyValues))
 	}
+
+	tarField := field.NewPath("ProvisionTar")
         r, err := os.Open(c.Platform.OpenStack.AciNetExt.ProvisionTar)
         if err != nil {
-        	fmt.Println("error")
-    	}
-        serviceNetwork := c.Networking.ServiceNetwork[0].String()
-        hostPrefix := c.Networking.ClusterNetwork[0].HostPrefix
-        networkType := c.Networking.NetworkType
-	clusterNetworkCIDR := &c.Networking.ClusterNetwork[0].CIDR
-        config := ExtractTarGz(r, serviceNetwork, clusterNetworkCIDR.String(), hostPrefix, networkType)
-        machineCIDR := c.Networking.MachineCIDR
-        // Validate against values from install config
-        if (strconv.Itoa(config.InfraVLAN) != c.Platform.OpenStack.AciNetExt.InfraVLAN) ||
-               (strconv.Itoa(config.ServiceVLAN) != c.Platform.OpenStack.AciNetExt.ServiceVLAN) ||
-                       (strconv.Itoa(config.KubeApiVLAN) != c.Platform.OpenStack.AciNetExt.KubeApiVLAN) ||
-                           DiffSubnets(config.NodeSubnet, machineCIDR) ||
-                               DiffSubnets(config.PodSubnet, clusterNetworkCIDR) {
-                                       panic("Install config and acc-provision not in sync")
-        }
+		allErrs = append(allErrs, field.Invalid(tarField, c.Platform.OpenStack.AciNetExt.ProvisionTar, err.Error()))
+    	} else {
+        	serviceNetwork := c.Networking.ServiceNetwork[0].String()
+                hostPrefix := c.Networking.ClusterNetwork[0].HostPrefix
+                networkType := c.Networking.NetworkType
+                clusterNetworkCIDR := &c.Networking.ClusterNetwork[0].CIDR
+                config, err := ExtractTarGz(r, serviceNetwork, clusterNetworkCIDR.String(), hostPrefix, networkType)
+                if err != nil {
+                        allErrs = append(allErrs, field.Invalid(tarField.Child("Unmarshal"),
+                                c.Platform.OpenStack.AciNetExt.ProvisionTar, err.Error()))
+                } else {
+			machineCIDR := c.Networking.MachineCIDR
+                        // Validate against values from install config
+
+                        if (strconv.Itoa(config.InfraVLAN) != c.Platform.OpenStack.AciNetExt.InfraVLAN) {
+                                allErrs = append(allErrs, field.Invalid(field.NewPath("InfraVLAN"),
+                                        c.Platform.OpenStack.AciNetExt.InfraVLAN, "InfraVLAN values in acc-provision input and install config have to be the same"))
+                        }
+                        if (strconv.Itoa(config.ServiceVLAN) != c.Platform.OpenStack.AciNetExt.ServiceVLAN) {
+                                allErrs = append(allErrs, field.Invalid(field.NewPath("ServiceVLAN"),
+                                        c.Platform.OpenStack.AciNetExt.ServiceVLAN, "ServiceVLAN values in acc-provision input and install config have to be the same"))
+                        }
+                        if (strconv.Itoa(config.KubeApiVLAN) != c.Platform.OpenStack.AciNetExt.KubeApiVLAN) {
+                                allErrs = append(allErrs, field.Invalid(field.NewPath("KubeApiVLAN"),
+                                        c.Platform.OpenStack.AciNetExt.KubeApiVLAN, "KubeApiVLAN values in acc-provision input and install config have to be the same"))
+                        }
+                        if DiffSubnets(config.NodeSubnet, machineCIDR) {
+                                allErrs = append(allErrs, field.Invalid(field.NewPath("MachineCIDR"),
+                                        c.Networking.MachineCIDR, "node_subnet in acc-provision input has to be the same as machineCIDR"))
+                        }
+                        if DiffSubnets(config.PodSubnet, clusterNetworkCIDR) {
+                                allErrs = append(allErrs, field.Invalid(field.NewPath("ClusterNetworkCIDR"),
+                                        clusterNetworkCIDR, "pod_subnet in acc-provision input has to be the same as clusterNetwork CIDR"))
+                        }
+		}
+	}
+
 	return allErrs
 }
 
@@ -184,17 +206,17 @@ func DiffSubnets(sub1 string, sub2 *ipnet.IPNet) bool {
         return false
 }
 
-func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, hostPrefix int32, netType string) HostConfigMap {
+func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, hostPrefix int32, netType string) (HostConfigMap, error) {
+	config := HostConfigMap{}
         uncompressedStream, err := gzip.NewReader(gzipStream)
         if err != nil {
-                panic("ExtractTarGz: NewReader failed")
+		return config, err
         }
 
         tarReader := tar.NewReader(uncompressedStream)
 
         manifests_dir := "manifests"
         os.Mkdir(manifests_dir, 0777)
-        config := HostConfigMap{}
 
         for true {
                 header, err := tarReader.Next()
@@ -204,7 +226,7 @@ func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, h
                 }
 
                 if err != nil {
-                        log.Fatalf("ExtractTarGz: Next() failed: %s", err.Error())
+			return config, err
                 }
 
                 switch header.Typeflag {
@@ -213,7 +235,7 @@ func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, h
                         fileName := manifests_dir + "/" + header.Name
                         outFile, err := os.Create(fileName)
                         if err != nil {
-                                log.Fatalf("ExtractTarGz: Create() failed: %s", err.Error())
+				return config, err
                         }
 
                         var buf bytes.Buffer
@@ -223,22 +245,22 @@ func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, h
 			// Unmarshal acc configmap to get acc-provision values
                         if strings.Contains(header.Name, "aci-containers-config") {
                                 t := AciContainersConfig{}
-                                err1 := yaml.Unmarshal(temp, &t)
-                                if err1 != nil {
-                                        log.Fatalf("error: %v", err1)
+                                err = yaml.Unmarshal(temp, &t)
+                                if err != nil {
+					return config, err
                                 }
-                                err2 := yaml.Unmarshal([]byte(t.Data.HostConfig), &config)
-                                if err2 != nil {
-                                        log.Fatalf("error: %v", err2)
+                                err = yaml.Unmarshal([]byte(t.Data.HostConfig), &config)
+                                if err != nil {
+					return config, err
                                 }
                         }
 
 			// Set cluster-network-03 fields as provided in install-config.yaml
                         if strings.Contains(header.Name, "cluster-network-03") {
                                 t := ClusterConfig03{}
-                                err1 := yaml.Unmarshal(temp, &t)
-                                if err1 != nil {
-                                        log.Fatalf("error: %v", err1)
+                                err = yaml.Unmarshal(temp, &t)
+                                if err != nil {
+					return config, err
                                 }
 				t.Spec.ClusterNetwork[0].CIDR = clusterCIDR
                                 t.Spec.ClusterNetwork[0].HostPrefix = hostPrefix
@@ -246,28 +268,24 @@ func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, h
                                 t.Spec.DefaultNetwork.Type = netType
                                 d, err := yaml.Marshal(&t)
 				if err != nil {
-					log.Fatalf("error: %v", err)
+					return config, err
 				}
                                 
 				err = ioutil.WriteFile(fileName, d, 0640)
                                 if err != nil {
-					log.Fatal(err)
+					return config, err
 				}
                         } else {
                         	if _, err := io.Copy(outFile, &buf); err != nil {
-                                	log.Fatalf("ExtractTarGz: Copy() failed: %s", err.Error())
+					return config, err
                         	}
                         	outFile.Close()
 			}
                 default:
-                        log.Fatalf(
-                                "ExtractTarGz: unknown type: %s in %s",
-                                header.Typeflag,
-                                header.Name)
-                }
+			return config, errors.New("Unsupported file type in tar")
 
         }
-        return config
+        return config, nil
 }
 
 func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorList {


### PR DESCRIPTION
Add field to input file like:
```
platform:
  openstack:
    aciNetExt:
      clusterSNATSubnet: 10.0.0.1/16
```

The clusterSNATSubnet has to be a valid subnet or IP address. In the latter case, our CNI treats it as a /32 subnet. If this field is not provided, the installer wont create a yaml manifest for this CR.

The input above will create inside manifests directory a yaml called "cluster-network-27-snat-policy-cr.yaml":

```
apiVersion: aci.snat/v1
kind: SnatPolicy
metadata:
  name: clusternetworksnatpolicy
spec:
  snatIp:
    -  10.0.0.1/16
```

- Also minor changes to error conditions in acc-provision validation to sync with the exisiting structure