### PR TITLE
Option to add destIp in Cluster SNAT CR

### DIFF
--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -178,6 +178,11 @@ func (no *Networking) Generate(dependencies asset.Parents) error {
 		if err := snatCRTmpl.Execute(snatData, data); err != nil {
 			return errors.Wrapf(err, "failed to create SNAT CR manifests from InstallConfig")
 		}
+		// add destIP if field present
+		if installConfig.Config.Platform.OpenStack.AciNetExt.ClusterSNATDest != "" {
+			dest := "  destIp:\n    -  " + installConfig.Config.Platform.OpenStack.AciNetExt.ClusterSNATDest + "\n"
+			snatData.WriteString(dest)
+		}
 		snatFile := &asset.File{Filename: noSNATCRFilename, Data: snatData.Bytes()}
 		no.FileList = append(no.FileList, snatFile)
 	}

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -12,7 +12,8 @@ type AciNetExtStruct struct {
         ProvisionTar            string		`json:"provisionTar,omitempty"`
         NeutronCIDR             *ipnet.IPNet    `json:"neutronCIDR,omitempty"`
         InstallerHostSubnet	string          `json:"installerHostSubnet"`
-	ClusterSNATSubnet       string          `json:"clusterSNATSubnet"`
+	ClusterSNATSubnet       string          `json:"clusterSNATPolicyIP"`
+	ClusterSNATDest         string          `json:"clusterSNATPolicyDestIP"`
 }
 
 // Platform stores all the global configuration that all

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -78,6 +78,18 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 			}	
 		}
 	}
+
+	// Check if snatCR Destination Subnet is a valid subnet or IP
+        if p.AciNetExt.ClusterSNATDest != "" {
+                _, _, err := net.ParseCIDR(p.AciNetExt.ClusterSNATDest)
+                if err != nil {
+                        ip := net.ParseIP(p.AciNetExt.ClusterSNATDest)
+                        if ip == nil {
+                                // error
+                                allErrs = append(allErrs, field.Invalid(fldPath.Child("ClusterSNATDest"), p.AciNetExt.ClusterSNATDest, err.Error()))
+                        }
+                }
+        }
 	return allErrs
 }
 


### PR DESCRIPTION
Config SNAT destination IP subnet/IP like:
```
platform:
  openstack:
    aciNetExt:
      clusterSNATPolicyIP: 10.0.0.1/16
      clusterSNATPolicyDestIP: 100.100.100.0/24

```
This will result in a SNAT policy like:
```
apiVersion: aci.snat/v1
kind: SnatPolicy
metadata:
  name: installerclusterdefault
spec:
  snatIp:
    -  10.0.0.1/16
  destIp:
    -  100.100.100.0/24
```