### PR TITLE
New way to resolve discrepancy between two input files

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -8,6 +8,7 @@ import (
         "gopkg.in/yaml.v2"
         "io"
         "io/ioutil"
+	"log"
 	"net"
         "os"
 	"sort"
@@ -175,12 +176,25 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
                         // Validate against values from install config
 			machineCIDR := c.Networking.MachineCIDR
                         if DiffSubnets(config.NodeSubnet, machineCIDR) {
-                                allErrs = append(allErrs, field.Invalid(field.NewPath("machineCIDR"),
-                                        c.Networking.MachineCIDR.String(), "node_subnet in acc-provision input(" + config.NodeSubnet + ") has to be the same as machineCIDR in install-config.yaml(" + machineCIDR.String() + ")"))
+				option := UserPrompt(config.NodeSubnet, machineCIDR, "node_subnet", "machineCIDR")
+				if (option == true) {
+					c.Networking.MachineCIDR, _ = ipnet.ParseCIDR(config.NodeSubnet)
+					log.Print("Setting machineCIDR to " + config.NodeSubnet)
+				} else {
+                                	allErrs = append(allErrs, field.Invalid(field.NewPath("machineCIDR"),
+                                        	c.Networking.MachineCIDR.String(), "node_subnet in acc-provision input(" + config.NodeSubnet + ") has to be the same as machineCIDR in install-config.yaml(" + machineCIDR.String() + ")"))
+				}
                         }
                         if DiffSubnets(config.PodSubnet, clusterNetworkCIDR) {
-                                allErrs = append(allErrs, field.Invalid(field.NewPath("clusterNetworkCIDR"),
-                                        clusterNetworkCIDR.String(), "pod_subnet in acc-provision input(" + config.PodSubnet + ") has to be the same as clusterNetwork:cidr in install-config.yaml(" + clusterNetworkCIDR.String() + ")"))
+				option := UserPrompt(config.PodSubnet, clusterNetworkCIDR, "pod_subnet", "clusterNetworkCIDR")
+				if (option == true) {
+					parsedCIDR, _ := ipnet.ParseCIDR(config.PodSubnet)
+					c.Networking.ClusterNetwork[0].CIDR = *parsedCIDR
+					log.Print("Setting clusterNetwork CIDR to " + config.PodSubnet)
+				} else {
+                                	allErrs = append(allErrs, field.Invalid(field.NewPath("clusterNetworkCIDR"),
+                                        	clusterNetworkCIDR.String(), "pod_subnet in acc-provision input(" + config.PodSubnet + ") has to be the same as clusterNetwork:cidr in install-config.yaml(" + clusterNetworkCIDR.String() + ")"))
+				}
                         }
 		}
 	}
@@ -195,6 +209,18 @@ func DiffSubnets(sub1 string, sub2 *ipnet.IPNet) bool {
                 return true
 	}
         return false
+}
+
+func UserPrompt(sub1 string, sub2 *ipnet.IPNet, item1 string, item2 string) bool {
+	var option string
+	log.Print("There's a discrepancy between " + item1 + "(" + sub1 + ") in acc-provision input and " + item2 + "(" + sub2.String() + ") in install-config.yaml")
+	log.Print("Enter Y to use acc-provision value, or N to exit installer and fix acc-provision tar")
+	fmt.Scanln(&option)
+	var op bool
+	if (option == "y" || option == "Y") {
+		op = true
+	}
+	return op
 }
 
 func ExtractTarGz(gzipStream io.Reader, serviceNet string, clusterCIDR string, hostPrefix int32, netType string) (HostConfigMap, error) {


### PR DESCRIPTION
Currently we validate acc-provision tar and install-config.yaml for these fields:
- pod_subnet and clusterNetwork:cidr
- node_subnet and machineCIDR

The code bails out if they are not the same.

This code change will now ask the user if they want to use the acc-provision value or exit installer and fix acc-provision tar.

The user will get a prompt, like:
There's a discrepancy between pod_subnet(10.129.0.1/16) in acc-provision input and clusterNetworkCIDR(10.19.0.0/16) in install-config.yaml
Enter Y to use acc-provision value, or N to exit installer and fix acc-provision tar

If the user enters Y/y, the code will ignore install-config.yaml value and use acc-provision tar value.
If the user enters N(or any other key), the installer will bail out like it does currently.