### PR TITLE
OpenStack: support "file" scheme for custom image urls

### DIFF
--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
         "math"
+	"net/url"
+	"path/filepath"
         "strconv"
         "strings"
 
@@ -71,10 +73,27 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 	cfg.BaseImageName = imageName
 	if isURL {
 		// Valid URL -> use baseImage as a URL that will be used to create new Glance image with name "<infraID>-rhcos".
-		localFilePath, err := cache.DownloadImageFile(baseImage)
+		var localFilePath string
+
+		url, err := url.Parse(baseImage)
 		if err != nil {
 			return nil, err
 		}
+
+		// We support 'http(s)' and 'file' schemes. If the scheme is http(s), then we will upload a file from that
+		// location. Otherwise will take local file path from the URL.
+		switch url.Scheme {
+		case "http", "https":
+			localFilePath, err = cache.DownloadImageFile(baseImage)
+			if err != nil {
+				return nil, err
+			}
+		case "file":
+			localFilePath = filepath.FromSlash(url.Path)
+		default:
+			return nil, errors.Errorf("Unsupported URL scheme: '%v'", url.Scheme)
+		}
+
 		cfg.BaseImageLocalFilePath = localFilePath
 	} else {
 		// Not a URL -> use baseImage value as an overridden Glance image name.


### PR DESCRIPTION
Now we support http(s) schemes only, but for disconnected installs
it's very convenient to specify the local file path to the image file.

This commit adds "file" scheme support, so users can set the location as
"file:///path/to/image".

Cherry-pick from https://github.com/openshift/installer/commit/beec1ab1eb55ce189072e5ef122674111ab5d5d5