### PR TITLE
Read CiscoACI fields from inventory and minor fixes

### DIFF
--- a/upi/openstack/021_network.yaml
+++ b/upi/openstack/021_network.yaml
@@ -4,9 +4,14 @@
   gather_facts: no
 
   tasks:
+  - name: 'Set MTU for the first neutron network'
+    command:
+      cmd: "openstack networrk set {{ os_network }} --mtu {{ neutron_network_mtu }}"
+    when: os_networking_type == "CiscoACI"
+
   - name: 'Create second node network'
     command:
-      cmd: "neutron net-create {{ os_network2 }} --apic:nested-domain-name openshift-domain --apic:nested-domain-type openshift --apic:nested_domain_infra_vlan 4093 --apic:nested_domain_service_vlan 2003"
+      cmd: "neutron net-create {{ os_network2 }} --apic:nested-domain-name openshift-domain --apic:nested-domain-type openshift --apic:nested_domain_infra_vlan {{ infra_vlan }} --apic:nested_domain_service_vlan {{ service_vlan }}"
     when: os_networking_type == "CiscoACI"
 
   - name: 'Set the second cluster network tag'

--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -37,5 +37,5 @@
       os_bootstrap_ignition: "{{ infraID }}-bootstrap-ignition.json"
 
   - name: 'Import variables for CiscoACI CNI'
-    import_playbook: common_ciscoaci.yaml
+    include: common_ciscoaci.yaml
     when: os_networking_type == "CiscoACI"

--- a/upi/openstack/common_ciscoaci.yaml
+++ b/upi/openstack/common_ciscoaci.yaml
@@ -1,14 +1,7 @@
-- hosts: localhost
-  gather_facts: no
-
-  vars_files:
-  - metadata.json
-
-  tasks:
-  - name: 'Compute CiscoACI resource names'
-    set_fact:
-      os_network2: "{{ infraID }}-network2"
-      os_subnet2: "{{ infraID }}-nodes2"
-      os_port_bootstrap2: "{{ infraID }}-bootstrap-port2"
-      os_port_master2: "{{ infraID }}-master-port2"
-      os_port_worker2: "{{ infraID }}-worker-port2
+- name: 'Compute CiscoACI resource names'
+  set_fact:
+    os_network2: "{{ infraID }}-network2"
+    os_subnet2: "{{ infraID }}-nodes2"
+    os_port_bootstrap2: "{{ infraID }}-bootstrap-port2"
+    os_port_master2: "{{ infraID }}-master-port2"
+    os_port_worker2: "{{ infraID }}-worker-port2"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -5,20 +5,22 @@ all:
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
       # User-provided values
-      os_subnet_range: '10.0.0.0/16'
-      os_flavor_master: 'm1.xlarge'
-      os_flavor_worker: 'm1.large'
-      os_image_rhcos: 'rhcos'
-      os_external_network: 'external'
+      os_subnet_range: '15.11.0.0/24'
+      os_subnet_range2: '16.11.0.0/24'
+      os_flavor_master: 'aci_rhel_huge'
+      os_flavor_worker: 'aci_rhel_huge'
+      os_image_rhcos: 'rhcos-4.4'
+      os_external_network: 'l3out-2'
       # OpenShift API floating IP address
-      os_api_fip: '203.0.113.23'
+      os_api_fip: '60.60.60.6'
+      dns_ip: '172.28.184.18'
       # OpenShift Ingress floating IP address
-      os_ingress_fip: '203.0.113.19'
+      os_ingress_fip: '60.60.60.8'
       # Service subnet cidr
       svc_subnet_range: '172.30.0.0/16'
       os_svc_network_range: '172.30.0.0/15'
       # Subnet pool prefixes
-      cluster_network_cidrs: '10.128.0.0/14'
+      cluster_network_cidrs: '15.128.0.0/14'
       # Subnet pool prefix length
       host_prefix: '23'
       # Name of the SDN.
@@ -32,3 +34,8 @@ all:
       # Number of provisioned Compute nodes.
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
+
+      infra_vlan: 4093
+      service_vlan: 2003
+      opflex_interface: ens4
+      node_interface: ens3

--- a/upi/openstack/update-control.sh
+++ b/upi/openstack/update-control.sh
@@ -1,25 +1,32 @@
-for index in $(seq 0 3); do
+#!/bin/bash
+# Script that creates control plane ignition files based on given args:
+
+CONTROL_COUNT=$1
+NODE_IFC=$2
+OPFLEX_IFC=$3
+INFRA_VLAN=$4
+MTU=$5
+
+for index in $(seq 0 $CONTROL_COUNT); do
     MASTER_HOSTNAME="$INFRA_ID-master-$index\n"
     sudo python3 -c "import base64, json, sys;
 ignition = json.load(sys.stdin);
 files = ignition['storage'].get('files', []);
 files.append({'path': '/etc/hostname', 'mode': 420, 'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + base64.standard_b64encode(b'$MASTER_HOSTNAME').decode().strip(), 'verification': {}}, 'filesystem': 'root'});
 
-ifcfg_ens3 = 'TYPE=Ethernet\nDEVICE=ens3\nONBOOT=yes\nBOOTPROTO=dhcp\nDEFROUTE=yes\nPROXY_METHOD=none\nBROWSER_ONLY=no\nMTU=1700\nIPV4_FAILURE_FATAL=no\nIPV6INIT=no'.encode();
+ifcfg_ens3 = 'TYPE=Ethernet\nDEVICE=$NODE_IFC\nONBOOT=yes\nBOOTPROTO=dhcp\nDEFROUTE=yes\nPROXY_METHOD=none\nBROWSER_ONLY=no\nMTU=$MTU\nIPV4_FAILURE_FATAL=no\nIPV6INIT=no'.encode();
 
 ifcfg_ens3_b64 = base64.standard_b64encode(ifcfg_ens3).decode().strip();
 
 files.append({'path': '/etc/sysconfig/network-scripts/ifcfg-ens3','mode': 420,'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + ifcfg_ens3_b64,'verification': {}},'filesystem': 'root',});
 
-
-ifcfg_ens4 = 'TYPE=Ethernet\nDEVICE=ens4\nONBOOT=yes\nBOOTPROTO=dhcp\nDEFROUTE=yes\nPROXY_METHOD=none\nBROWSER_ONLY=no\nMTU=1700\nIPV4_FAILURE_FATAL=no\nIPV6INIT=no'.encode();
+ifcfg_ens4 = 'TYPE=Ethernet\nDEVICE=$OPFLEX_IFC\nONBOOT=yes\nBOOTPROTO=dhcp\nDEFROUTE=yes\nPROXY_METHOD=none\nBROWSER_ONLY=no\nMTU=$MTU\nIPV4_FAILURE_FATAL=no\nIPV6INIT=no'.encode();
 
 ifcfg_ens4_b64 = base64.standard_b64encode(ifcfg_ens4).decode().strip()
 
 files.append({'path': '/etc/sysconfig/network-scripts/ifcfg-ens4','mode': 420,'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + ifcfg_ens4_b64,'verification': {}},'filesystem': 'root',});
 
-
-opflex_conn = 'VLAN=yes\nTYPE=Vlan\nPHYSDEV=ens4\nVLAN_ID=4093\nREORDER_HDR=yes\nGVRP=no\nMVRP=no\nPROXY_METHOD=none\nBROWSER_ONLY=no\nBOOTPROTO=dhcp\nDEFROUTE=no\nIPV4_FAILURE_FATAL=no\nIPV6INIT=no\nNAME=opflex-conn\nDEVICE=ens4.4093\nONBOOT=yes\nMTU=1600'.encode();
+opflex_conn = 'VLAN=yes\nTYPE=Vlan\nPHYSDEV=$OPFLEX_IFC\nVLAN_ID=$INFRA_VLAN\nREORDER_HDR=yes\nGVRP=no\nMVRP=no\nPROXY_METHOD=none\nBROWSER_ONLY=no\nBOOTPROTO=dhcp\nDEFROUTE=no\nIPV4_FAILURE_FATAL=no\nIPV6INIT=no\nNAME=opflex-conn\nDEVICE=$OPFLEX_IFC.$INFRA_VLAN\nONBOOT=yes\nMTU=$MTU'.encode();
 
 opflex_conn_b64 = base64.standard_b64encode(opflex_conn).decode().strip();
 

--- a/upi/openstack/update_control.py
+++ b/upi/openstack/update_control.py
@@ -1,0 +1,25 @@
+import os
+import yaml
+
+os.system('export INFRA_ID=$(jq -r .infraID metadata.json)')
+# Read inventory.yaml for CiscoACI CNI variables
+with open("inventory.yaml", 'r') as stream:
+    try:
+        inventory = yaml.safe_load(stream)['all']['hosts']['localhost']
+    except yaml.YAMLError as exc:
+        print(exc)
+
+if 'neutron_network_mtu' not in inventory:
+    neutron_network_mtu = "1500"
+else:
+    neutron_network_mtu = str(inventory['neutron_network_mtu'])
+
+try:
+    infra_vlan = str(inventory['infra_vlan'])
+    node_interface = inventory['node_interface']
+    opflex_interface = inventory['opflex_interface']
+    os_cp_nodes_number = inventory['os_cp_nodes_number']
+except:
+    print("The inventory.yaml must have infra_vlan, node_interface and opflex_interface fields set")
+
+os.system('./update-control.sh ' + str(os_cp_nodes_number) + ' ' + node_interface + ' ' + str(opflex_interface) + ' ' + infra_vlan + ' ' + str(neutron_network_mtu))


### PR DESCRIPTION
1. Read fields node_interface, opflex_interface, neutron_network_mtu(default 1500) and infra_vlan from inventory.yaml to create ignition files
2. Use neutron_network_mtu field from [1] to set MTU for the first neutron network
3. Run ./update_control.py to generate master ignition files