### PR TITLE
Changes to user input, SGs, field names

### DIFF
--- a/upi/openstack/01_security-groups.yaml
+++ b/upi/openstack/01_security-groups.yaml
@@ -149,6 +149,14 @@
       port_range_min: 2379
       port_range_max: 2380
 
+  - name: 'Create master-sg rule "etcd" for pod network'
+    os_security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ cluster_network_cidrs }}"
+      port_range_min: 2379
+      port_range_max: 2380
+
   - name: 'Create master-sg rule "master ingress services (TCP)"'
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"
@@ -191,6 +199,15 @@
       remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 5353
       port_range_max: 5353
+
+  - name: 'Create worker-sg rule "DNS (UDP)"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_worker }}"
+      remote_ip_prefix: "{{ cluster_network_cidrs }}"
+      protocol: udp
+      port_range_min: 53
+      port_range_max: 53
+    when: os_networking_type == "CiscoACI"
 
   - name: 'Create worker-sg rule "Ingress HTTP"'
     os_security_group_rule:

--- a/upi/openstack/021_network.yaml
+++ b/upi/openstack/021_network.yaml
@@ -9,29 +9,29 @@
       cmd: "openstack networrk set {{ os_network }} --mtu {{ neutron_network_mtu }}"
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Create second node network'
+  - name: 'Create ACI containers node network'
     command:
-      cmd: "neutron net-create {{ os_network2 }} --apic:nested-domain-name openshift-domain --apic:nested-domain-type openshift --apic:nested_domain_infra_vlan {{ infra_vlan }} --apic:nested_domain_service_vlan {{ service_vlan }}"
+      cmd: "neutron net-create {{ os_aci_containers_network }} --apic:nested-domain-name openshift-domain --apic:nested-domain-type openshift --apic:nested_domain_infra_vlan {{ infra_vlan }} --apic:nested_domain_service_vlan {{ service_vlan }}"
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Set the second cluster network tag'
+  - name: 'Set the ACI containers cluster network tag'
     command:
-      cmd: "openstack network set --tag {{ cluster_id_tag }} {{ os_network2 }}"
+      cmd: "openstack network set --tag {{ cluster_id_tag }} {{ os_aci_containers_network }}"
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Create a subnet2'
+  - name: 'Create the ACI containers subnet'
     os_subnet:
-      name: "{{ os_subnet2 }}"
-      network_name: "{{ os_network2 }}"
+      name: "{{ os_aci_containers_subnet }}"
+      network_name: "{{ os_aci_containers_network }}"
       no_gateway_ip: yes
-      cidr: "{{ os_subnet_range2 }}"
-      allocation_pool_start: "{{ os_subnet_range2 | next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_subnet_range2 | ipaddr('last_usable') }}"
+      cidr: "{{ os_aci_containers_subnet_range }}"
+      allocation_pool_start: "{{ os_aci_containers_subnet_range | next_nth_usable(10) }}"
+      allocation_pool_end: "{{ os_aci_containers_subnet_range | ipaddr('last_usable') }}"
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Set the cluster subnet tag'
+  - name: 'Set the ACI containers cluster subnet tag'
     command:
-      cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet2 }}"
+      cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_aci_containers_subnet }}"
     when: os_networking_type == "CiscoACI"
 
   - name: 'Set dns nameserver'

--- a/upi/openstack/02_network.yaml
+++ b/upi/openstack/02_network.yaml
@@ -19,13 +19,17 @@
     command:
       cmd: "openstack network set --tag {{ cluster_id_tag }} {{ os_network }}"
 
+  - name: 'Create the cluster address-scope'
+    command:
+      cmd: "neutron address-scope-update {{ aci_containers_addr_scope }} --apic:distinguished_names type=dict VRF={{ aci_containers_l3out_vrf }}"
+
+  - name: 'Create the subnetpool'
+    command:
+      cmd: "neutron subnetpool-create --pool-prefix {{ os_subnet_range }} --address-scope {{ aci_containers_addr_scope }} {{ aci_containers_subnet_pool }}"
+
   - name: 'Create a subnet'
-    os_subnet:
-      name: "{{ os_subnet }}"
-      network_name: "{{ os_network }}"
-      cidr: "{{ os_subnet_range }}"
-      allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+    command:
+      cmd: "openstack subnet create --network {{ os_network }}  --subnet-pool {{ aci_containers_subnet_pool }} --subnet-range {{ os_subnet_range }} --allocation-pool start={{ os_subnet_range | next_nth_usable(10) }},end={{ os_subnet_range | ipaddr('last_usable') }} --dhcp {{ os_subnet }} --prefix-length {{aci_containers_prefix_length }}"
 
   - name: 'Set the cluster subnet tag'
     command:

--- a/upi/openstack/03_bootstrap.yaml
+++ b/upi/openstack/03_bootstrap.yaml
@@ -25,15 +25,15 @@
     command:
       cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap }}"
 
-  - name: 'Create the second bootstrap server port'
+  - name: 'Create the ACI containers bootstrap server port'
     os_port:
-      name: "{{ os_port_bootstrap2 }}"
-      network: "{{ os_network2 }}"
+      name: "{{ os_aci_containers_port_bootstrap }}"
+      network: "{{ os_aci_containers_network }}"
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Set second bootstrap port tag'
+  - name: 'Set ACI containers bootstrap port tag'
     command:
-      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap2 }}"
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_aci_containers_port_bootstrap }}"
     when: os_networking_type == "CiscoACI"
 
   - name: 'Create the bootstrap server'
@@ -56,7 +56,7 @@
       auto_ip: no
       nics:
       - port-name: "{{ os_port_bootstrap }}"
-      - port-name: "{{ os_port_bootstrap2 }}"
+      - port-name: "{{ os_aci_containers_port_bootstrap }}"
     when: os_networking_type == "CiscoACI"
 
   - name: 'Create the bootstrap floating IP'

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -29,18 +29,18 @@
       cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
 
-  - name: 'Create the second Control Plane ports'
+  - name: 'Create the ACI containers Control Plane ports'
     os_port:
       name: "{{ item.1 }}-{{ item.0 }}"
-      network: "{{ os_network2 }}"
-    with_indexed_items: "{{ [os_port_master2] * os_cp_nodes_number }}"
+      network: "{{ os_aci_containers_network }}"
+    with_indexed_items: "{{ [os_aci_containers_port_master] * os_cp_nodes_number }}"
     register: ports
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Set second Control Plane ports tag'
+  - name: 'Set ACI containers Control Plane ports tag'
     command:
       cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
-    with_indexed_items: "{{ [os_port_master2] * os_cp_nodes_number }}"
+    with_indexed_items: "{{ [os_aci_containers_port_master] * os_cp_nodes_number }}"
     when: os_networking_type == "CiscoACI"
 
   - name: 'List the Control Plane Trunks'
@@ -70,7 +70,7 @@
       userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
       nics:
       - port-name: "{{ os_port_master }}-{{ item.0 }}"
-      - port-name: "{{ os_port_master2 }}-{{ item.0 }}"
+      - port-name: "{{ os_aci_containers_port_master }}-{{ item.0 }}"
     with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"
     when: os_networking_type == "CiscoACI"
 

--- a/upi/openstack/05_compute-nodes.yaml
+++ b/upi/openstack/05_compute-nodes.yaml
@@ -27,18 +27,18 @@
       cmd: "openstack port set --tag {{ [cluster_id_tag] }} {{ item.1 }}-{{ item.0 }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
 
-  - name: 'Create the second Compute ports'
+  - name: 'Create the ACI containers Compute ports'
     os_port:
       name: "{{ item.1 }}-{{ item.0 }}"
-      network: "{{ os_network2 }}"
-    with_indexed_items: "{{ [os_port_worker2] * os_compute_nodes_number }}"
+      network: "{{ os_aci_containers_network }}"
+    with_indexed_items: "{{ [os_aci_containers_port_worker] * os_compute_nodes_number }}"
     register: ports
     when: os_networking_type == "CiscoACI"
 
-  - name: 'Set second Compute ports tag'
+  - name: 'Set ACI containers Compute ports tag'
     command:
       cmd: "openstack port set --tag {{ [cluster_id_tag] }} {{ item.1 }}-{{ item.0 }}"
-    with_indexed_items: "{{ [os_port_worker2] * os_compute_nodes_number }}"
+    with_indexed_items: "{{ [os_aci_containers_port_worker] * os_compute_nodes_number }}"
     when: os_networking_type == "CiscoACI"
 
   - name: 'List the Compute Trunks'
@@ -64,7 +64,7 @@
       userdata: "{{ lookup('file', 'worker.ign') | string }}"
       nics:
       - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-      - port-name: "{{ os_port_worker2 }}-{{ item.0 }}"
+      - port-name: "{{ os_aci_containers_port_worker }}-{{ item.0 }}"
     with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
     when: os_networking_type == "CiscoACI"
 

--- a/upi/openstack/common_ciscoaci.yaml
+++ b/upi/openstack/common_ciscoaci.yaml
@@ -1,7 +1,7 @@
 - name: 'Compute CiscoACI resource names'
   set_fact:
-    os_network2: "{{ infraID }}-network2"
-    os_subnet2: "{{ infraID }}-nodes2"
-    os_port_bootstrap2: "{{ infraID }}-bootstrap-port2"
-    os_port_master2: "{{ infraID }}-master-port2"
-    os_port_worker2: "{{ infraID }}-worker-port2"
+    os_aci_containers_network: "{{ infraID }}-acicontainers-network"
+    os_aci_containers_subnet: "{{ infraID }}-acicontainers-nodes"
+    os_aci_containers_port_bootstrap: "{{ infraID }}-acicontainers-bootstrap-port"
+    os_aci_containers_port_master: "{{ infraID }}-acicontainers-master-port"
+    os_aci_containers_port_worker: "{{ infraID }}-acicontainers-worker-port"

--- a/upi/openstack/down-03_bootstrap.yaml
+++ b/upi/openstack/down-03_bootstrap.yaml
@@ -22,6 +22,6 @@
 
   - name: 'Remove the second bootstrap server port'
     os_port:
-      name: "{{ os_port_bootstrap2 }}"
+      name: "{{ os_aci_containers_port_bootstrap }}"
       state: absent
     when: os_networking_type == "CiscoACI"

--- a/upi/openstack/down-04_control-plane.yaml
+++ b/upi/openstack/down-04_control-plane.yaml
@@ -36,9 +36,9 @@
       state: absent
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
 
-  - name: 'Remove the second Control Plane ports'
+  - name: 'Remove the ACI containers Control Plane ports'
     os_port:
       name: "{{ item.1 }}-{{ item.0 }}"
       state: absent
-    with_indexed_items: "{{ [os_port_master2] * os_cp_nodes_number }}"
+    with_indexed_items: "{{ [os_aci_containers_port_master] * os_cp_nodes_number }}"
     when: os_networking_type == "CiscoACI"

--- a/upi/openstack/down-05_compute-nodes.yaml
+++ b/upi/openstack/down-05_compute-nodes.yaml
@@ -36,9 +36,9 @@
       state: absent
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
 
-  - name: 'Remove the second Compute ports'
+  - name: 'Remove the ACI containers Compute ports'
     os_port:
       name: "{{ item.1 }}-{{ item.0 }}"
       state: absent
-    with_indexed_items: "{{ [os_port_worker2] * os_compute_nodes_number }}"
+    with_indexed_items: "{{ [os_aci_containers_port_worker] * os_compute_nodes_number }}"
     when: os_networking_type == "CiscoACI"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -35,7 +35,10 @@ all:
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
 
-      infra_vlan: 4093
-      service_vlan: 2003
+      acc_provision_tar: /fullpath/to/tar/file
       opflex_interface: ens4
       node_interface: ens3
+      aci_containers_addr_scope: addr-scp-openshiftupi 
+      aci_containers_l3out_vrf: uni/tn-common/ctx-sauto_l3out-1_vrf
+      aci_containers_subnet_pool: subpool-openshiftupi
+      aci_containers_prefix_length: 27


### PR DESCRIPTION

1. Read VLAN values from accprovision Tar file

Add field 'acc_provision_tar' to inventory.yaml like this:
all:
  hosts:
    localhost:
      acc_provision_tar: /fullpath/to/tar/file

2. Modify Cisco ACI resource names to include prefix "aci-containers"

3. Add pod network security groups for pod network for DNS(workers) and ETCD(masters)

4. Neutron address-scope and pool creation
Mandatory fields required:
      aci_containers_addr_scope: addr-scp-openshiftupi
      aci_containers_l3out_vrf: uni/tn-common/ctx-sauto_l3out-1_vrf
      aci_containers_subnet_pool: subpool-openshiftupi
      aci_containers_prefix_length: 27