### PR TITLE
Post-install step to create cluster SNAT policy

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -34,6 +34,7 @@ all:
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
       aci_cni:
+        kubeconfig: /path/to/kubeconfig
         acc_provision_tar: /home/noiro/openupi/aci_deployment.yaml.tar.gz
         network_interfaces:
           node:

--- a/upi/openstack/post-install.yaml
+++ b/upi/openstack/post-install.yaml
@@ -1,0 +1,14 @@
+- hosts: all
+  gather_facts: no
+
+  tasks:
+  - name: 'Create snat policy file'
+    template:
+      src: cluster_snat_policy.conf.j2
+      dest: cluster_snatpolicy.yaml
+
+  - name: 'Create cluster SNAT policy'
+    k8s:
+      state: present
+      kubeconfig: "{{ aci_cni['kubeconfig'] }}"
+      src: cluster_snatpolicy.yaml

--- a/upi/openstack/templates/cluster_snat_policy.conf.j2
+++ b/upi/openstack/templates/cluster_snat_policy.conf.j2
@@ -1,0 +1,7 @@
+apiVersion: aci.snat/v1
+kind: SnatPolicy
+metadata:
+  name: installerclusterdefault
+spec:
+  snatIp:
+    -  {{ aci_cni['cluster_snat_policy_ip'] }}


### PR DESCRIPTION
Add snat IP and kubeconfig path to inventory inside aci_cni field like
aci_cni:
  cluster_snat_policy_ip:
  kubeconfig: