### PR TITLE
Set primaryClusterNetwork tag on node network

### DIFF
--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -8,7 +8,7 @@
   - name: 'Compute resource names'
     set_fact:
       cluster_id_tag: "openshiftClusterID={{ infraID }}"
-      os_network: "{{ infraID }}-network"
+      os_network: "{{ infraID }}-primaryClusterNetwork"
       os_subnet: "{{ infraID }}-nodes"
       os_router: "{{ infraID }}-external-router"
       # Port names


### PR DESCRIPTION
To distinguish the node network from the second kube network