### PR TITLE
Set defaults for network interface fields

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -6,19 +6,20 @@ all:
         # opflex network mtu is set to 1500 if not provided
         acc_provision_tar: /home/noiro/openupi/aci_deployment.yaml1.tar.gz
         app_profile: aci-containers-openupi # OPTIONAL
-        node_epg: aci-containers-nodes
+        node_epg: aci-containers-nodes # OPTIONAL
         cluster_snat_policy_ip: </32>
         infra_vlan: 4093 # OPTIONAL
         kubeconfig: /home/noiro/openupi/openshift-env/upi/auth/kubeconfig
         network_interfaces:
           node:
             bd: uni/tn-prj_<openstack-project-id>/BD-aci-containers-<system-id>-node-bd # OPTIONAL
-            name: ens3
+            name: ens3 # OPTIONAL
             vrf: uni/tn-<vrf-tenant>/ctx-<vrf-name> # OPTIONAL
+            mtu: 1500 # OPTIONAL
           opflex:
-            mtu: '1500' # OPTIONAL
-            name: ens4
-            subnet: 16.11.0.0/24
+            mtu: 1500 # OPTIONAL
+            name: ens4 # OPTIONAL
+            subnet: 192.168.0.0/16 # OPTIONAL
         service_vlan: 1033 # OPTIONAL
       ansible_connection: local
       ansible_python_interpreter: '{{ansible_playbook_python}}'

--- a/upi/openstack/update_ign.py
+++ b/upi/openstack/update_ign.py
@@ -68,27 +68,45 @@ try:
 except OSError as e:
     print ("Error: %s - %s." % (e.filename, e.strerror))
 
-if 'mtu' not in inventory['network_interfaces']['opflex']:
-    neutron_network_mtu = "1500"
-else:
-    neutron_network_mtu = str(inventory['network_interfaces']['opflex']['mtu'])
-
-if 'node_epg' not in inventory:
-    node_epg = "aci-containers-nodes"
-else:
-    node_epg = inventory['node_epg']
-
 # Set infra_vlan field in inventory.yaml using accprovision tar value
 try:
     with open(original_inventory, 'r') as stream:
         cur_yaml = yaml.safe_load(stream)
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['app_profile'] = app_profile
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['infra_vlan'] = aci_infra_vlan
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['node_epg'] = node_epg
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['service_vlan'] = service_vlan
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['mtu'] = neutron_network_mtu
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['vrf'] = aci_vrf_dn
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['bd'] = aci_nodebd_dn
+
+    cur_yaml['all']['hosts']['localhost']['aci_cni']['app_profile'] = app_profile
+    cur_yaml['all']['hosts']['localhost']['aci_cni']['infra_vlan'] = aci_infra_vlan
+
+    if 'node_epg' not in inventory:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['node_epg'] = "aci-containers-nodes"
+
+    cur_yaml['all']['hosts']['localhost']['aci_cni']['service_vlan'] = service_vlan
+
+    if 'network_interfaces' not in inventory:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces'] = dict()
+
+    if 'opflex' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex'] = dict()
+
+    if 'node' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node'] = dict()
+
+    if 'mtu' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['mtu'] = 1500
+
+    if 'mtu' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['mtu'] = 1500
+
+    if 'name' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['name'] = 'ens4'
+
+    if 'name' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['name'] = 'ens3'
+
+    if 'subnet' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['subnet'] = '192.168.208.0/20'
+
+    cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['vrf'] = aci_vrf_dn
+    cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['bd'] = aci_nodebd_dn
 
     if cur_yaml:
         with open(processed_inventory,'w') as yamlfile:
@@ -96,8 +114,8 @@ try:
 except:
     print("Unable to edit inventory.yaml")
 try:
-    node_interface = inventory['network_interfaces']['node']['name']
-    opflex_interface = inventory['network_interfaces']['opflex']['name']
+    node_interface = cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['name']
+    opflex_interface = cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['name']
     master_count = localhost['os_cp_nodes_number']
     worker_count = localhost['os_compute_nodes_number']
 except:
@@ -105,6 +123,7 @@ except:
 
 infra_vlan = str(aci_infra_vlan)
 infra_id = os.environ.get('INFRA_ID', 'openshift').encode()
+neutron_network_mtu = str(cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['mtu'])
 
 def update(hostname,ignition):
 


### PR DESCRIPTION
Set defaults for the following fields in inventory.yaml file:
node network interface to ens3
opflex network interface to ens4
opflex network subnet to 192.168.208.0/20