### PR TITLE
allow multiple nameservers

### DIFF
--- a/upi/openstack/021_network.yaml
+++ b/upi/openstack/021_network.yaml
@@ -36,7 +36,8 @@
 
   - name: 'Set dns nameserver'
     command:
-      cmd: "openstack subnet set --dns-nameserver {{ aci_cni['dns_ip'] }} {{ os_subnet }}"
+      cmd: "openstack subnet set --dns-nameserver {{ item }} {{ os_aci_containers_subnet }}"
     when:
       - os_networking_type == "CiscoACI"
-      - aci_cni['dns_ip'] is defined
+      - aci_cni.dns_ips is defined and aci_cni.dns_ips | length > 0
+    with_items: "{{ aci_cni.dns_ips }}"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -20,7 +20,7 @@ all:
             name: ens4 # Optional
             subnet: 192.168.208.0/20 # Optional
         cluster_snat_policy_ip: <IP> # Optional, no default value
-        dns_ip: <IP> # Optional, no default value
+        dns_ips: [list of nameservers] # Optional, no default value
         # The following are derived from acc_provision_tar file
         # and populated after running the update_ign.py
         app_profile: aci-containers-<system-id> # Derived


### PR DESCRIPTION
this aligns the code with the docs.

Docs say: DNS IPs shall be set on the subnet of the secondary network.
Playbook actually sets it on the primary network's subnet.

That failed for us (address of cloud API endpoint could not be resolved, it was using the dhcp port of the secondary network) . So setting it on the supposedly correct subnet made it work for us.

Only a draft PR, since I am not sure that this is actually how it's supposed to work. I would have expected that the primary network is being used for that, but I am definitely the last person to be authorative at all on that topic.