### PR TITLE
Make network playbook idempotent.

### DIFF
--- a/upi/openstack/021_network.yaml
+++ b/upi/openstack/021_network.yaml
@@ -26,14 +26,22 @@
       - node_network.stdout != ""
     register: service_vlan
 
+  - name: 'Check if ACI containers node network already exists with different vlan configuration'
+    assert:
+      that:
+        - infra_vlan.stdout|int == aci_cni['infra_vlan']
+        - service_vlan.stdout|int == aci_cni['service_vlan']
+      fail_msg: "{{ os_aci_containers_network }} already exists with different vlan configuration."
+    when:
+      - os_networking_type == "CiscoACI"
+      - node_network.stdout != ""
+
   - name: 'Create ACI containers node network'
     command:
       cmd: "neutron net-create {{ os_aci_containers_network }} --apic:nested-domain-name openshift-domain --apic:nested-domain-type openshift --apic:nested_domain_infra_vlan {{ aci_cni['infra_vlan'] }} --apic:nested_domain_service_vlan {{ aci_cni['service_vlan'] }}"
     when:
       - os_networking_type == "CiscoACI"
-      - (node_network.stdout == "" ) or
-        (infra_vlan is defined and infra_vlan.stdout|int != aci_cni['infra_vlan']) or
-        (service_vlan is defined and service_vlan.stdout|int != aci_cni['service_vlan'])
+      - node_network.stdout == ""
 
   - name: 'Set the ACI containers cluster network tag'
     command:
@@ -56,6 +64,16 @@
       - containers_subnet.stdout != ""
     register: containers_subnet_cidr
 
+  - name: 'Check if ACI containers subnet already exists with different cidr'
+    assert:
+      that:
+        - aci_cni['network_interfaces']['opflex']['subnet'] in containers_subnet_cidr.stdout_lines|list
+      fail_msg: "{{ os_aci_containers_subnet }} already exists with different cidr."
+    when:
+      - os_networking_type == "CiscoACI"
+      - containers_subnet.stdout != ""
+
+
   - name: 'Create the ACI containers subnet'
     os_subnet:
       name: "{{ os_aci_containers_subnet }}"
@@ -66,8 +84,7 @@
       allocation_pool_end: "{{ aci_cni['network_interfaces']['opflex']['subnet'] | ipaddr('last_usable') }}"
     when:
       - os_networking_type == "CiscoACI"
-      - (containers_subnet.stdout == "") or
-        (aci_cni['network_interfaces']['opflex']['subnet'] not in containers_subnet_cidr.stdout_lines|list)
+      - containers_subnet.stdout == ""
 
   - name: 'Set the ACI containers cluster subnet tag'
     command:

--- a/upi/openstack/021_network.yaml
+++ b/upi/openstack/021_network.yaml
@@ -4,15 +4,57 @@
   gather_facts: no
 
   tasks:
+  - name: 'list network'
+    command:
+      cmd: "openstack network list --name {{ os_aci_containers_network }} --tag {{ cluster_id_tag }}"
+    when: os_networking_type == "CiscoACI"
+    register: node_network
+
+  - name: 'get nested domain infra vlan of network'
+    command:
+      cmd: "neutron net-show {{ os_aci_containers_network }} -f value -c apic:nested_domain_infra_vlan"
+    when:
+      - os_networking_type == "CiscoACI"
+      - node_network.stdout != ""
+    register: infra_vlan
+
+  - name: 'get nested domain service vlan of network'
+    command:
+      cmd: "neutron net-show {{ os_aci_containers_network }} -f value -c apic:nested_domain_service_vlan"
+    when:
+      - os_networking_type == "CiscoACI"
+      - node_network.stdout != ""
+    register: service_vlan
+
   - name: 'Create ACI containers node network'
     command:
       cmd: "neutron net-create {{ os_aci_containers_network }} --apic:nested-domain-name openshift-domain --apic:nested-domain-type openshift --apic:nested_domain_infra_vlan {{ aci_cni['infra_vlan'] }} --apic:nested_domain_service_vlan {{ aci_cni['service_vlan'] }}"
-    when: os_networking_type == "CiscoACI"
+    when:
+      - os_networking_type == "CiscoACI"
+      - (node_network.stdout == "" ) or
+        (infra_vlan is defined and infra_vlan.stdout|int != aci_cni['infra_vlan']) or
+        (service_vlan is defined and service_vlan.stdout|int != aci_cni['service_vlan'])
 
   - name: 'Set the ACI containers cluster network tag'
     command:
       cmd: "openstack network set --tag {{ cluster_id_tag }} {{ os_aci_containers_network }}"
+    when:
+      - os_networking_type == "CiscoACI"
+      - node_network.stdout == ""
+
+  - name: 'list containers subnet'
+    command:
+      cmd: "openstack subnet list --name {{ os_aci_containers_subnet }} --network {{ os_aci_containers_network }} --tag {{ cluster_id_tag }}"
     when: os_networking_type == "CiscoACI"
+    register: containers_subnet
+
+  - name: 'get cidr of containers subnet'
+    command:
+      cmd: "openstack subnet list --name {{ os_aci_containers_subnet }} --network {{ os_aci_containers_network }} --tag {{ cluster_id_tag }} -f value -c Subnet"
+    when:
+      - os_networking_type == "CiscoACI"
+      - containers_subnet.stdout != ""
+    register: containers_subnet_cidr
 
   - name: 'Create the ACI containers subnet'
     os_subnet:
@@ -22,12 +64,17 @@
       cidr: "{{ aci_cni['network_interfaces']['opflex']['subnet'] }}"
       allocation_pool_start: "{{ aci_cni['network_interfaces']['opflex']['subnet'] | next_nth_usable(10) }}"
       allocation_pool_end: "{{ aci_cni['network_interfaces']['opflex']['subnet'] | ipaddr('last_usable') }}"
-    when: os_networking_type == "CiscoACI"
+    when:
+      - os_networking_type == "CiscoACI"
+      - (containers_subnet.stdout == "") or
+        (aci_cni['network_interfaces']['opflex']['subnet'] not in containers_subnet_cidr.stdout_lines|list)
 
   - name: 'Set the ACI containers cluster subnet tag'
     command:
       cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_aci_containers_subnet }}"
-    when: os_networking_type == "CiscoACI"
+    when:
+      - os_networking_type == "CiscoACI"
+      - containers_subnet.stdout == ""
 
   - name: 'Set MTU for the ACI containers network'
     command:

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -92,12 +92,21 @@
     when: os_networking_type == "CiscoACI"
     register: primary_subnet_pool
 
+  - name: 'Check if subnetpool already exists with different subnet range.'
+    assert:
+      that:
+        - os_subnet_range in primary_subnet_pool.stdout
+      fail_msg: "node_network_subnet_pool already exists with different subnet range."
+    when:
+      - os_networking_type == "CiscoACI"
+      - primary_subnet_pool.stdout != ""
+
   - name: 'Create the subnetpool'
     command:
       cmd: "neutron subnetpool-create --pool-prefix {{ os_subnet_range }} --address-scope node_network_address_scope node_network_subnet_pool"
     when:
       - os_networking_type == "CiscoACI"
-      - primary_subnet_pool.stdout == "" or os_subnet_range not in primary_subnet_pool.stdout
+      - primary_subnet_pool.stdout == ""
 
   - name: 'list primary subnet'
     command:
@@ -113,12 +122,21 @@
       - primary_cluster_subnet.stdout != ""
     register: primary_subnet_cidr
 
+  - name: 'Check if primary cluster subnet already exists with different subnet range.'
+    assert:
+      that:
+        - os_subnet_range in primary_subnet_cidr.stdout_lines|list
+      fail_msg: "{{ os_subnet }} already exists with different subnet range."
+    when:
+      - os_networking_type == "CiscoACI"
+      - primary_cluster_subnet.stdout != ""
+
   - name: 'Create a subnet'
     command:
       cmd: "openstack subnet create --network {{ os_network }}  --subnet-pool node_network_subnet_pool --subnet-range {{ os_subnet_range }} --allocation-pool start={{ os_subnet_range | next_nth_usable(10) }},end={{ os_subnet_range | ipaddr('last_usable') }} --dhcp {{ os_subnet }}"
     when:
       - os_networking_type == "CiscoACI"
-      - primary_cluster_subnet.stdout == "" or os_subnet_range not in primary_subnet_cidr.stdout_lines|list
+      - primary_cluster_subnet.stdout == ""
 
   - name: 'Set tags on  primary cluster subnet'
     command:

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -16,10 +16,45 @@
       name: "{{ os_network }}"
     when: os_networking_type != "CiscoACI"
 
+  - name: 'list network'
+    command:
+      cmd: "openstack network list --name {{ os_network }} --tag {{ cluster_id_tag }}"
+    when: os_networking_type == "CiscoACI"
+    register: cluster_network
+
+  - name: 'get network epg contract masters attributes'
+    command:
+      cmd: "neutron net-show {{ os_network }} -f json -c apic:epg_contract_masters"
+    when:
+      - os_networking_type == "CiscoACI"
+      - cluster_network.stdout != ""
+    register: epg_bd
+
+  - name: 'convert network show output into dictionary type'
+    set_fact:
+         epg_bd_out: "{{ epg_bd.stdout| from_json }}"
+    when:
+      - os_networking_type == "CiscoACI"
+      - cluster_network.stdout != ""
+      - epg_bd.stdout != ""
+
+  - name: 'set facts for network epg contract masters attributes'
+    set_fact:
+         app_profile_name: "{{ epg_bd_out['apic:epg_contract_masters'].0.app_profile_name }}"
+         node_epg: "{{ epg_bd_out['apic:epg_contract_masters'].0.name }}"
+    when:
+      - os_networking_type == "CiscoACI"
+      - cluster_network.stdout != ""
+      - epg_bd_out is defined
+
   - name: 'Create the cluster network with aci-containers-nodes EPG contract relationship for node network'
     command:
       cmd: "neutron net-create {{ os_network }} --apic:epg_contract_masters list=true type=dict app_profile_name={{ aci_cni['app_profile'] }},name={{ aci_cni['node_epg'] }} --apic:distinguished_names type=dict BridgeDomain={{ aci_cni['network_interfaces']['node']['bd'] }}"
-    when: os_networking_type == "CiscoACI"
+    when:
+      - os_networking_type == "CiscoACI"
+      - (cluster_network.stdout == "" ) or
+        (app_profile_name is defined and app_profile_name != aci_cni['app_profile']) or
+        (node_epg is defined and node_epg != aci_cni['node_epg'])
 
   - name: 'Set tags on the  primary cluster network'
     command:
@@ -38,20 +73,52 @@
       allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
     when: os_networking_type != "CiscoACI"
 
+  - name: 'List the cluster address-scope'
+    command:
+      cmd: "openstack address scope list --name node_network_address_scope"
+    when: os_networking_type == "CiscoACI"
+    register: cluster_address_scope
+
   - name: 'Create the cluster address-scope'
     command:
       cmd: "neutron address-scope-create node_network_address_scope 4 --apic:distinguished_names type=dict VRF={{ aci_cni['network_interfaces']['node']['vrf'] }}"
+    when:
+      - os_networking_type == "CiscoACI"
+      - cluster_address_scope.stdout == ""
+
+  - name: 'list subnet pool'
+    command:
+      cmd: "openstack subnet pool list --name node_network_subnet_pool -f value -c Prefixes"
     when: os_networking_type == "CiscoACI"
+    register: primary_subnet_pool
 
   - name: 'Create the subnetpool'
     command:
       cmd: "neutron subnetpool-create --pool-prefix {{ os_subnet_range }} --address-scope node_network_address_scope node_network_subnet_pool"
+    when:
+      - os_networking_type == "CiscoACI"
+      - primary_subnet_pool.stdout == "" or os_subnet_range not in primary_subnet_pool.stdout
+
+  - name: 'list primary subnet'
+    command:
+      cmd: "openstack subnet list --name {{ os_subnet }} --network {{ os_network }} --tag {{ cluster_id_tag }}"
     when: os_networking_type == "CiscoACI"
+    register: primary_cluster_subnet
+
+  - name: 'get cidr of primary subnet'
+    command:
+      cmd: "openstack subnet list --name {{ os_subnet }} --network {{ os_network }} --tag {{ cluster_id_tag }} -f value -c Subnet"
+    when:
+      - os_networking_type == "CiscoACI"
+      - primary_cluster_subnet.stdout != ""
+    register: primary_subnet_cidr
 
   - name: 'Create a subnet'
     command:
       cmd: "openstack subnet create --network {{ os_network }}  --subnet-pool node_network_subnet_pool --subnet-range {{ os_subnet_range }} --allocation-pool start={{ os_subnet_range | next_nth_usable(10) }},end={{ os_subnet_range | ipaddr('last_usable') }} --dhcp {{ os_subnet }}"
-    when: os_networking_type == "CiscoACI"
+    when:
+      - os_networking_type == "CiscoACI"
+      - primary_cluster_subnet.stdout == "" or os_subnet_range not in primary_subnet_cidr.stdout_lines|list
 
   - name: 'Set tags on  primary cluster subnet'
     command:
@@ -126,13 +193,20 @@
     - os_networking_type == "Kuryr"
     - pods_subnet_pool.stdout == ""
 
+  - name: 'list external router'
+    command:
+      cmd: "openstack router list --name {{ os_router }}"
+    register: ext_router_list
+
   - name: 'Create external router'
     os_router:
       name: "{{ os_router }}"
       network: "{{ os_external_network }}"
       interfaces:
       - "{{ os_subnet }}"
-    when: os_external_network is defined and os_external_network|length>0
+    when:
+      - os_external_network is defined and os_external_network|length>0
+      - ext_router_list.stdout == ""
 
   - name: 'Set external router tag'
     command:
@@ -140,6 +214,11 @@
     when:
     - os_networking_type == "Kuryr"
     - os_external_network is defined and os_external_network|length>0
+
+  - name: 'Get API port'
+    command:
+      cmd: "openstack port list --tags {{ os_port_api }}"
+    register: api_port
 
   - name: 'Create the API port'
     os_port:
@@ -150,10 +229,19 @@
       fixed_ips:
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
+    when:
+      - api_port.stdout == ""
 
   - name: 'Set API port tag'
     command:
-      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_api }}"
+      cmd: "openstack port set --tag {{ os_port_api }} --tag {{ cluster_id_tag }} {{ os_port_api }}"
+    when:
+      - api_port.stdout == ""
+
+  - name: 'Get Ingress port'
+    command:
+      cmd: "openstack port list --tags {{ os_port_ingress }}"
+    register: ingress_port
 
   - name: 'Create the Ingress port'
     os_port:
@@ -164,10 +252,14 @@
       fixed_ips:
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
+    when:
+      - ingress_port.stdout == ""
 
   - name: 'Set the Ingress port tag'
     command:
-      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_ingress }}"
+      cmd: "openstack port set --tag {{ os_port_ingress }} --tag {{ cluster_id_tag }} {{ os_port_ingress }}"
+    when:
+      - ingress_port.stdout == ""
 
   # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
   # ports, let's use the CLI instead
@@ -188,10 +280,16 @@
       cmd: "openstack network set {{ os_network }} --mtu {{ aci_cni['network_interfaces']['node']['mtu'] }}"
     when: os_networking_type == "CiscoACI"
 
+  - name: 'Get dns nameserver'
+    command:
+      cmd: "openstack subnet  show {{ os_subnet }} -c dns_nameservers -f value"
+    register: dns_nameserver_list
+
   - name: 'Set dns nameserver'
     command:
       cmd: "openstack subnet set --dns-nameserver {{ item }} {{ os_subnet }}"
     when:
       - os_networking_type == "CiscoACI"
       - aci_cni.dns_ips is defined and aci_cni.dns_ips | length > 0
+      - item not in dns_nameserver_list.stdout
     with_items: "{{ aci_cni.dns_ips }}"


### PR DESCRIPTION
Primary cluster network create condition is updated. Cluster network
creation task should execute only when there is no already created
network with the same cluster id or network exists but there is change
in app profile or node epg.
Subnet pool creation task should execute when there is no already
created subnet pool or subnet pool exists but there is
change subnet range.
Subnet creation task should execute when there is no already created subnet
with a given cluster id or subnet exists but there is change in subnet_range.
Similar enhancement is done for aci containers network and aci container
subnet.