### PR TITLE
Removing aci_containers_port deletion from down_bootstrap.yaml.

### DIFF
--- a/upi/openstack/down-bootstrap.yaml
+++ b/upi/openstack/down-bootstrap.yaml
@@ -18,9 +18,3 @@
     os_port:
       name: "{{ os_port_bootstrap }}"
       state: absent
-
-  - name: 'Remove the second bootstrap server port'
-    os_port:
-      name: "{{ os_aci_containers_port_bootstrap }}"
-      state: absent
-    when: os_networking_type == "CiscoACI"


### PR DESCRIPTION
The bootstrap is created on single node network and presence of secondary network interface is removed