### PR TITLE
add playbook to disable Octavia LB creation for NetworkType CiscoACI

### DIFF
--- a/upi/openstack/disable-octavia.yaml
+++ b/upi/openstack/disable-octavia.yaml
@@ -1,0 +1,11 @@
+- hosts: all
+  gather_facts: no
+  tasks:
+
+  - name: Ensure Octavia is disabled
+    lineinfile:
+      path: "{{ playbook_dir }}/manifests/cloud-provider-config.yaml"
+      regexp: '(\s+)use-octavia = .+'
+      line: '\1use-octavia = false'
+      backrefs: yes
+    when: os_networking_type == "CiscoACI"


### PR DESCRIPTION
(cherry picked from commit e81d89c02b8d7a88006e880826fbc7891da87634)