### PR TITLE
Update configuration to disables the Octavia integration.

### DIFF
--- a/upi/openstack/disable-octavia.yaml
+++ b/upi/openstack/disable-octavia.yaml
@@ -2,10 +2,47 @@
   gather_facts: no
   tasks:
 
-  - name: Ensure Octavia is disabled
+  - name: Get content of cloud-provider-config.yaml file.
+    shell: cat {{ playbook_dir }}/manifests/cloud-provider-config.yaml
+    register: cloud_provider_config
+
+  - name: |
+      Ensure Octavia is disabled.
+      For case when [LoadBalancer] section does exists and Octavia
+      intergration is enabled.
     lineinfile:
       path: "{{ playbook_dir }}/manifests/cloud-provider-config.yaml"
-      regexp: '(\s+)use-octavia = .+'
-      line: '\1use-octavia = false'
+      regexp: '(\s+)enabled = .+'
+      line: '\1enabled = false'
       backrefs: yes
-    when: os_networking_type == "CiscoACI"
+    when:
+      - cloud_provider_config.stdout.find('[LoadBalancer]') != -1
+      - cloud_provider_config.stdout.find('enabled') != -1
+      - os_networking_type == "CiscoACI"
+
+  - name: |
+      Ensure Octavia is disabled.
+      For case when [LoadBalancer] section does exists and Octavia
+      integration option is not set.
+    lineinfile:
+      path: "{{ playbook_dir }}/manifests/cloud-provider-config.yaml"
+      insertafter: '\s*\[LoadBalancer\]'
+      line: '    enabled = false'
+      state: present
+    when:
+      - cloud_provider_config.stdout.find('[LoadBalancer]') != -1
+      - cloud_provider_config.stdout.find('enabled') == -1
+      - os_networking_type == "CiscoACI"
+
+  - name: |
+      Ensure Octavia is disabled.
+      Adding enabled = false in [LoadBalancer] section of config
+      disables the Octavia integration.
+    lineinfile:
+      path: "{{ playbook_dir }}/manifests/cloud-provider-config.yaml"
+      insertbefore: '\s*\[Global\]'
+      line: "    [LoadBalancer]\n    enabled = false"
+      state: present
+    when:
+      - cloud_provider_config.stdout.find('[LoadBalancer]') == -1
+      - os_networking_type == "CiscoACI"


### PR DESCRIPTION
Remove mentions of use-octavia
The option no longer exists in cloud-provider-openstack.

(cherry picked from commit d82f343963aeb10eeeba1effe42cf89f59a08db4)