### PR TITLE
Update name of the interfaces as with openstack 17.1 interface name format got changed.

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -108,13 +108,13 @@ all:
         kubeconfig: /path/kubeconfig
         network_interfaces:
           node:
-            name: ens3 # Optional
+            name: enp3s0 # Optional
             mtu: 1500 # Optional
             bd: uni/tn-prj_<openstack-prj-id>/BD-aci-containers-<system-id>-node-bd # Derived
             vrf: uni/tn-<vrf-tenant>/ctx-<vrf-name> # Derived
           opflex:
             mtu: 1500 # Optional
-            name: ens4 # Optional
+            name: enp4s0 # Optional
             subnet: 192.168.208.0/20 # Optional
         cluster_snat_policy_ip: <IP> # Optional, no default value
         dns_ips: [<list of dns ip's>] # Optional, no default value

--- a/upi/openstack/templates/99_master-networkscripts.yaml
+++ b/upi/openstack/templates/99_master-networkscripts.yaml
@@ -17,15 +17,15 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens3.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_enp3s0.base64 }}
           verification: {}
-        path: {{ ifcfg_ens3.path }}
+        path: {{ ifcfg_enp3s0.path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens4.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_enp4s0.base64 }}
           verification: {}
-        path: {{ ifcfg_ens4.path }}
+        path: {{ ifcfg_enp4s0.path }}
         mode: 420
         filesystem: root
       - contents:

--- a/upi/openstack/templates/99_worker-networkscripts.yaml
+++ b/upi/openstack/templates/99_worker-networkscripts.yaml
@@ -17,15 +17,15 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens3.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_enp3s0.base64 }}
           verification: {}
-        path: {{ ifcfg_ens3.path }}
+        path: {{ ifcfg_enp3s0.path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens4.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_enp4s0.base64 }}
           verification: {}
-        path: {{ ifcfg_ens4.path }}
+        path: {{ ifcfg_enp4s0.path }}
         mode: 420
         filesystem: root
       - contents:

--- a/upi/openstack/update_ign.py
+++ b/upi/openstack/update_ign.py
@@ -97,10 +97,10 @@ try:
         cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['mtu'] = 1500
 
     if 'name' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['name'] = 'ens4'
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['name'] = 'enp4s0'
 
     if 'name' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']:
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['name'] = 'ens3'
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['name'] = 'enp3s0'
 
     if 'subnet' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
         cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['subnet'] = '192.168.208.0/20'
@@ -130,7 +130,7 @@ def update(hostname,ignition):
 
     config_data = {}
 
-    ifcfg_ens3 = ("""TYPE=Ethernet
+    ifcfg_enp3s0 = ("""TYPE=Ethernet
 DEVICE=""" + node_interface + """
 ONBOOT=yes
 BOOTPROTO=dhcp
@@ -140,16 +140,16 @@ BROWSER_ONLY=no
 MTU=""" + neutron_network_mtu + """
 IPV4_FAILURE_FATAL=no
 IPV6INIT=no
-ETHTOOL_OPTS="-K ens3 tx-checksum-ip-generic off"
-NAME="System ens3"
+ETHTOOL_OPTS="-K enp3s0 tx-checksum-ip-generic off"
+NAME="System enp3s0"
 UUID=21d47e65-8523-1a06-af22-6f121086f085
 """).encode()
 
-    ifcfg_ens3_b64 = base64.standard_b64encode(ifcfg_ens3).decode().strip()
+    ifcfg_enp3s0_b64 = base64.standard_b64encode(ifcfg_enp3s0).decode().strip()
 
-    config_data['ifcfg_ens3'] = {'base64': ifcfg_ens3_b64, 'path': '/etc/sysconfig/network-scripts/ifcfg-ens3'}
+    config_data['ifcfg_enp3s0'] = {'base64': ifcfg_enp3s0_b64, 'path': '/etc/sysconfig/network-scripts/ifcfg-enp3s0'}
 
-    ifcfg_ens4 = ("""TYPE=Ethernet
+    ifcfg_enp4s0 = ("""TYPE=Ethernet
 DEVICE=""" + opflex_interface + """
 ONBOOT=yes
 BOOTPROTO=dhcp
@@ -159,14 +159,14 @@ BROWSER_ONLY=no
 MTU=""" + opflex_network_mtu + """
 IPV4_FAILURE_FATAL=no
 IPV6INIT=no
-ETHTOOL_OPTS="-K ens4 tx-checksum-ip-generic off"
-NAME="System ens4"
+ETHTOOL_OPTS="-K enp4s0 tx-checksum-ip-generic off"
+NAME="System enp4s0"
 UUID=e27f182b-d125-2c43-5a30-43524d0229ac
 """).encode()
 
-    ifcfg_ens4_b64 = base64.standard_b64encode(ifcfg_ens4).decode().strip()
+    ifcfg_enp4s0_b64 = base64.standard_b64encode(ifcfg_enp4s0).decode().strip()
 
-    config_data['ifcfg_ens4'] = {'base64': ifcfg_ens4_b64, 'path': '/etc/sysconfig/network-scripts/ifcfg-ens4'}
+    config_data['ifcfg_enp4s0'] = {'base64': ifcfg_enp4s0_b64, 'path': '/etc/sysconfig/network-scripts/ifcfg-enp4s0'}
 
     opflex_conn = ("""VLAN=yes
 TYPE=Vlan
@@ -270,10 +270,10 @@ METRIC0=1000
 
          files.append(
              {
-                 'path': config_data['ifcfg_ens3']['path'],
+                 'path': config_data['ifcfg_enp3s0']['path'],
                  'mode': 420,
                  'contents': {
-                     'source': 'data:text/plain;charset=utf-8;base64,' + config_data['ifcfg_ens3']['base64'],
+                     'source': 'data:text/plain;charset=utf-8;base64,' + config_data['ifcfg_enp3s0']['base64'],
                      'verification': {}
                  },
                  'filesystem': 'root',
@@ -281,10 +281,10 @@ METRIC0=1000
 
          files.append(
              {
-                 'path': config_data['ifcfg_ens4']['path'],
+                 'path': config_data['ifcfg_enp4s0']['path'],
                  'mode': 420,
                  'contents': {
-                     'source': 'data:text/plain;charset=utf-8;base64,' + config_data['ifcfg_ens4']['base64'],
+                     'source': 'data:text/plain;charset=utf-8;base64,' + config_data['ifcfg_enp4s0']['base64'],
                      'verification': {}
                  },
                  'filesystem': 'root',


### PR DESCRIPTION
With openstack 17.1, we are seeing interface name format got changed e.g., the interfaces are named as `enpXs0` instead of `ensX`. This PR is make corresponding updates in inventory.yaml, update_ign.py and network-script template files.