### PR TITLE
Fixing network.yaml external router creation role

### DIFF
--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -162,15 +162,6 @@
       network: "{{ os_external_network }}"
       interfaces:
       - "{{ os_subnet }}"
-    when:
-      - os_external_network is defined and os_external_network|length>0
-      - ext_router_list.stdout == ""
-
-  - name: 'Add IPv6 subnet to the external router'
-    openstack.cloud.router:
-      name: "{{ os_router }}"
-      interfaces:
-      - "{{ os_subnet }}"
       - "{{ os_subnet6 }}"
     when:
     - os_external_network is defined


### PR DESCRIPTION
Current changes ended up running both ext-rtr  and dualstack rtr in case where os_subnet_range6 is defined. Current openshift on openstack doesn't support IPV6 dualstack and this os_subnet6_range should be disabled in inventory.yaml as such only one role for creating external router should run