### PR TITLE
Backport changes to update default names for node and opflex interfaces.

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -98,13 +98,13 @@ all:
         kubeconfig: /path/kubeconfig
         network_interfaces:
           node:
-            name: ens3 # Optional
+            name: enp3s0 # Optional
             mtu: 1500 # Optional
             bd: uni/tn-prj_<openstack-prj-id>/BD-aci-containers-<system-id>-node-bd # Derived
             vrf: uni/tn-<vrf-tenant>/ctx-<vrf-name> # Derived
           opflex:
             mtu: 1500 # Optional
-            name: ens4 # Optional
+            name: enp4s0 # Optional
             subnet: 192.168.208.0/20 # Optional
         cluster_snat_policy_ip: <IP> # Optional, no default value
         dns_ips: [<list of dns ip's>] # Optional, no default value

--- a/upi/openstack/templates/99_master-networkscripts.yaml
+++ b/upi/openstack/templates/99_master-networkscripts.yaml
@@ -17,26 +17,26 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens3.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['ifcfg_'+ node_interface].base64 }}
           verification: {}
-        path: {{ ifcfg_ens3.path }}
+        path: {{ config_data['ifcfg_'+ node_interface].path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens4.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['ifcfg_'+ opflex_interface].base64 }}
           verification: {}
-        path: {{ ifcfg_ens4.path }}
+        path: {{ config_data['ifcfg_'+ opflex_interface].path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_opflex_conn.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['ifcfg_opflex_conn'].base64 }}
           verification: {}
-        path: {{ ifcfg_opflex_conn.path }}
+        path: {{ config_data['ifcfg_opflex_conn'].path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ route_opflex_conn.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['route_opflex_conn'].base64 }}
           verification: {}
-        path: {{ route_opflex_conn.path }}
+        path: {{ config_data['route_opflex_conn'].path }}
         mode: 420
         filesystem: root

--- a/upi/openstack/templates/99_worker-networkscripts.yaml
+++ b/upi/openstack/templates/99_worker-networkscripts.yaml
@@ -17,26 +17,26 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens3.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['ifcfg_'+ node_interface].base64 }}
           verification: {}
-        path: {{ ifcfg_ens3.path }}
+        path: {{ config_data['ifcfg_'+ node_interface].path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_ens4.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['ifcfg_'+ opflex_interface].base64 }}
           verification: {}
-        path: {{ ifcfg_ens4.path }}
+        path: {{ config_data['ifcfg_'+ opflex_interface].path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ ifcfg_opflex_conn.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['ifcfg_opflex_conn'].base64 }}
           verification: {}
-        path: {{ ifcfg_opflex_conn.path }}
+        path: {{ config_data['ifcfg_opflex_conn'].path }}
         mode: 420
         filesystem: root
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ route_opflex_conn.base64 }}
+          source: data:text/plain;charset=utf-8;base64,{{ config_data['route_opflex_conn'].base64 }}
           verification: {}
-        path: {{ route_opflex_conn.path }}
+        path: {{ config_data['route_opflex_conn'].path }}
         mode: 420
         filesystem: root

--- a/upi/openstack/update_ign.py
+++ b/upi/openstack/update_ign.py
@@ -97,10 +97,10 @@ try:
         cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['mtu'] = 1500
 
     if 'name' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['name'] = 'ens4'
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['name'] = 'enp4s0'
 
     if 'name' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']:
-        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['name'] = 'ens3'
+        cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['node']['name'] = 'enp3s0'
 
     if 'subnet' not in cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']:
         cur_yaml['all']['hosts']['localhost']['aci_cni']['network_interfaces']['opflex']['subnet'] = '192.168.208.0/20'
@@ -232,11 +232,13 @@ METRIC0=1000
         # Add master and worker network scripts to bootstrap ignition
         env = Environment(loader = FileSystemLoader('./templates'), trim_blocks=True, lstrip_blocks=True)
         template_worker = env.get_template('99_worker-networkscripts.yaml')
-        rendered_worker = template_worker.render(config_data)
+        rendered_worker = template_worker.render(
+            config_data=config_data, node_interface=node_interface, opflex_interface=opflex_interface)
         worker_b64 = base64.standard_b64encode(rendered_worker.encode()).decode().strip()
 
         template_master = env.get_template('99_master-networkscripts.yaml')
-        rendered_master = template_master.render(config_data)
+        rendered_master = template_master.render(
+            config_data=config_data, node_interface=node_interface, opflex_interface=opflex_interface)
         master_b64 = base64.standard_b64encode(rendered_master.encode()).decode().strip()
 
         files.append(


### PR DESCRIPTION
Addressed following in this commit:
- Updated default interface names for node and opflex interfaces which we observe in OSP17.1.
- Fixed variable reference issue from in networkscripts template files.